### PR TITLE
支持小米 MiMo TTS 与 18 种中文情绪路由

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 ## ✨ 功能概览
 
-- 支持双 TTS 服务商：`siliconflow` / `minimax`
-- 情绪路由：按 `happy/sad/angry/neutral` 映射不同音色和语速
+- 支持多 TTS 服务商：`siliconflow` / `minimax` / `mimo`
+- 情绪路由：支持 18 种中文语境情绪，并可映射不同音色和语速
+- MiMo 支持情绪标签、唱歌、方言/角色等风格标签，以及对话中的一次性临时风格指定
 - 四类可独立配置策略（均支持 UMO 黑白名单）
   - 自动语音输出 `voice_output`
   - 文字+语音同时输出 `text_voice_output`
@@ -48,8 +49,21 @@
 - `tts_engine.provider` 可选：
   - `siliconflow`
   - `minimax`
+  - `mimo`
 
-### 3) MiniMax（已支持）
+### 3) MiMo（已支持）
+
+接口使用兼容 OpenAI Chat Completions 的 MiMo TTS 端点，支持：
+
+- 预置音色：`冰糖` / `茉莉` / `苏打` / `白桦` / `Mia` / `Chloe` / `Milo` / `Dean`
+- 18 种情绪标签：开心、悲伤、愤怒、恐惧、惊讶、兴奋、委屈、平静、冷漠、怅然、欣慰、无奈、愧疚、释然、嫉妒、厌倦、忐忑、动情
+- 唱歌标签（仅 `mimo-v2.5-tts` 支持）
+- MiMo 专属风格配置：整体语调、音色定位、人设腔调、方言、角色扮演
+- 对话临时指定风格/音色，例如“用东北话说……”“用冰糖的音色说……”
+
+通用 `voice_map` 默认保持空，避免将 MiMo 中文标签误传给其他服务商；使用 MiMo 时即使映射为空，也会根据情绪自动添加对应中文标签。
+
+### 4) MiniMax（已支持）
 
 接口使用 `https://api.minimaxi.com/v1/t2a_v2`，支持：
 
@@ -66,7 +80,7 @@
 - `subtitle_enable`
 - `pronunciation_dict`（可选）
 
-### 4) 情绪路由面板
+### 5) 情绪路由面板
 
 - `emotion_route.enable = true` 时显示子面板：
   - `voice_map`
@@ -75,7 +89,7 @@
   - `keywords`
 - 关闭后不显示映射配置，界面更简洁。
 
-### 5) 分段语音参数
+### 6) 分段语音参数
 
 - `segmented_tts.enable`
 - `interval_mode = fixed/adaptive`

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -14,7 +14,8 @@
         "description": "语音服务商",
         "options": [
           "siliconflow",
-          "minimax"
+          "minimax",
+          "mimo"
         ],
         "default": "siliconflow"
       },
@@ -206,6 +207,104 @@
             "type": "bool",
             "description": "是否返回字幕",
             "default": false
+          }
+        }
+      },
+      "mimo": {
+        "type": "object",
+        "description": "MiMo 配置",
+        "condition": {
+          "provider": "mimo"
+        },
+        "items": {
+          "url": {
+            "type": "string",
+            "description": "API 地址",
+            "default": "https://token-plan-cn.xiaomimimo.com/v1"
+          },
+          "key": {
+            "type": "string",
+            "description": "API Key",
+            "default": ""
+          },
+          "model": {
+            "type": "string",
+            "description": "模型名",
+            "default": "mimo-v2.5-tts",
+            "options": [
+              "mimo-v2.5-tts",
+              "mimo-v2.5-tts-voicedesign",
+              "mimo-v2.5-tts-voiceclone"
+            ],
+            "hint": "预置音色模型支持唱歌；voicedesign/voiceclone 不支持唱歌。"
+          },
+          "voice": {
+            "type": "string",
+            "description": "默认音色",
+            "default": "mimo_default",
+            "hint": "建议填写具体 Voice ID，如冰糖/茉莉/Mia/Chloe；不要长期依赖 mimo_default 集群别名。对话里也可临时指定：“用冰糖的音色说……”。"
+          },
+          "format": {
+            "type": "string",
+            "description": "音频格式",
+            "options": [
+              "mp3",
+              "wav"
+            ],
+            "default": "mp3"
+          },
+          "speed": {
+            "type": "float",
+            "description": "默认语速（MiMo 可能忽略）",
+            "default": 1.0
+          },
+          "overall_tone": {
+            "type": "string",
+            "description": "整体语调",
+            "default": "",
+            "hint": "可选：温柔/高冷/活泼/严肃/慵懒/俏皮/深沉/干练/凌厉。也支持对话临时指定，如“用温柔语调说……”。"
+          },
+          "timbre_positioning": {
+            "type": "string",
+            "description": "音色定位",
+            "default": "",
+            "hint": "可选：磁性/醇厚/清亮/空灵/稚嫩/苍老/甜美/沙哑/醇雅。也支持对话临时指定，如“用清亮声音说……”。"
+          },
+          "persona_accent": {
+            "type": "string",
+            "description": "人设腔调",
+            "default": "",
+            "hint": "可选：夹子音/御姐音/正太音/大叔音/台湾腔。也支持对话临时指定，如“用夹子音说……”。"
+          },
+          "dialect": {
+            "type": "string",
+            "description": "方言",
+            "default": "",
+            "hint": "可选：东北话/四川话/河南话/粤语。也支持对话临时指定，如“用东北话说……”。"
+          },
+          "role_play": {
+            "type": "string",
+            "description": "角色扮演",
+            "default": "",
+            "hint": "可选：孙悟空/林黛玉。也支持对话临时指定，如“用孙悟空说……”。"
+          },
+          "style_prompt": {
+            "type": "string",
+            "description": "额外自由风格标签",
+            "default": "",
+            "hint": "自由补充 MiMo 风格标签；可留空。优先使用上方五个结构化配置项，只有无法归类时再填写这里。"
+          },
+          "seed_text": {
+            "type": "string",
+            "description": "可选 user 消息",
+            "default": "",
+            "hint": "自然语言风格指令/对话历史，不会被朗读；可留空。voicedesign 模型可填写音色描述。"
+          },
+          "sing_voice": {
+            "type": "string",
+            "description": "唱歌专用音色",
+            "default": "",
+            "hint": "留空则跟随默认音色 voice。只有想让唱歌使用不同音色时才填写。可选预置音色：冰糖/茉莉/苏打/白桦/Mia/Chloe/Milo/Dean。"
           }
         }
       }
@@ -500,7 +599,7 @@
           "prompt_hint": {
             "type": "text",
             "description": "注入到提示词的说明",
-            "default": "请在回复开头添加 [EMO:happy|sad|angry|neutral]，该标记仅供系统解析，不对用户显示。"
+            "default": "请在回复开头添加一个隐藏情绪标记，格式如 [EMO:happy]。可选情绪：happy/sad/angry/fear/surprise/excited/wronged/neutral/cold/melancholy/gratified/helpless/guilty/relieved/jealous/weary/anxious/affectionate。该标记仅供系统解析，不对用户显示。"
           }
         }
       },
@@ -518,6 +617,9 @@
               "type": "string"
             },
             "default": [
+              "开心",
+              "高兴",
+              "哈哈",
               "happy",
               "great",
               "lol"
@@ -525,26 +627,263 @@
           },
           "sad": {
             "type": "list",
-            "description": "难过关键词",
+            "description": "悲伤关键词",
             "items": {
               "type": "string"
             },
             "default": [
+              "悲伤",
+              "难过",
+              "伤心",
+              "呜呜",
               "sad",
-              "sorry",
               "cry"
             ]
           },
           "angry": {
             "type": "list",
-            "description": "生气关键词",
+            "description": "愤怒关键词",
             "items": {
               "type": "string"
             },
             "default": [
+              "愤怒",
+              "生气",
+              "气死",
+              "可恶",
               "angry",
-              "mad",
-              "annoyed"
+              "mad"
+            ]
+          },
+          "sing": {
+            "type": "list",
+            "description": "唱歌关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "sing",
+              "singing",
+              "唱歌",
+              "唱首歌",
+              "来首歌",
+              "唱一首",
+              "唱一句",
+              "给你唱",
+              "唱",
+              "歌"
+            ]
+          },
+          "fear": {
+            "type": "list",
+            "description": "恐惧关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "恐惧",
+              "害怕",
+              "吓死",
+              "好可怕",
+              "fear",
+              "scared"
+            ]
+          },
+          "surprise": {
+            "type": "list",
+            "description": "惊讶关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "惊讶",
+              "哇",
+              "震惊",
+              "不会吧",
+              "surprise",
+              "wow"
+            ]
+          },
+          "excited": {
+            "type": "list",
+            "description": "兴奋关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "兴奋",
+              "激动",
+              "冲冲冲",
+              "excited",
+              "thrilled"
+            ]
+          },
+          "wronged": {
+            "type": "list",
+            "description": "委屈关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "委屈",
+              "冤枉",
+              "嘤嘤嘤",
+              "wronged"
+            ]
+          },
+          "neutral": {
+            "type": "list",
+            "description": "平静关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "平静",
+              "冷静",
+              "正常",
+              "neutral",
+              "calm"
+            ]
+          },
+          "cold": {
+            "type": "list",
+            "description": "冷漠关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "冷漠",
+              "冷淡",
+              "无所谓",
+              "随便",
+              "cold",
+              "indifferent"
+            ]
+          },
+          "melancholy": {
+            "type": "list",
+            "description": "怅然关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "怅然",
+              "惆怅",
+              "感慨",
+              "melancholy",
+              "wistful"
+            ]
+          },
+          "gratified": {
+            "type": "list",
+            "description": "欣慰关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "欣慰",
+              "安心",
+              "值得了",
+              "gratified",
+              "pleased"
+            ]
+          },
+          "helpless": {
+            "type": "list",
+            "description": "无奈关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "无奈",
+              "没办法",
+              "只能这样",
+              "helpless"
+            ]
+          },
+          "guilty": {
+            "type": "list",
+            "description": "愧疚关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "愧疚",
+              "抱歉",
+              "对不起",
+              "guilty",
+              "sorry"
+            ]
+          },
+          "relieved": {
+            "type": "list",
+            "description": "释然关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "释然",
+              "放心了",
+              "松了口气",
+              "relieved"
+            ]
+          },
+          "jealous": {
+            "type": "list",
+            "description": "嫉妒关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "嫉妒",
+              "羡慕",
+              "酸了",
+              "jealous",
+              "envious"
+            ]
+          },
+          "weary": {
+            "type": "list",
+            "description": "厌倦关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "厌倦",
+              "累了",
+              "够了",
+              "weary",
+              "tired"
+            ]
+          },
+          "anxious": {
+            "type": "list",
+            "description": "忐忑关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "忐忑",
+              "紧张",
+              "不安",
+              "担心",
+              "anxious",
+              "nervous"
+            ]
+          },
+          "affectionate": {
+            "type": "list",
+            "description": "动情关键词",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "动情",
+              "深情",
+              "感动",
+              "爱",
+              "affectionate",
+              "loving"
             ]
           }
         }
@@ -558,25 +897,120 @@
         "items": {
           "neutral": {
             "type": "string",
-            "description": "中性音色",
-            "default": ""
+            "description": "平静音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
           },
           "happy": {
             "type": "string",
-            "description": "开心音色",
-            "default": ""
+            "description": "开心音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
           },
           "sad": {
             "type": "string",
-            "description": "难过音色",
-            "default": ""
+            "description": "悲伤音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
           },
           "angry": {
             "type": "string",
-            "description": "生气音色",
-            "default": ""
+            "description": "愤怒音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "fear": {
+            "type": "string",
+            "description": "恐惧音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "surprise": {
+            "type": "string",
+            "description": "惊讶音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "excited": {
+            "type": "string",
+            "description": "兴奋音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "wronged": {
+            "type": "string",
+            "description": "委屈音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "cold": {
+            "type": "string",
+            "description": "冷漠音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "melancholy": {
+            "type": "string",
+            "description": "怅然音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "gratified": {
+            "type": "string",
+            "description": "欣慰音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "helpless": {
+            "type": "string",
+            "description": "无奈音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "guilty": {
+            "type": "string",
+            "description": "愧疚音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "relieved": {
+            "type": "string",
+            "description": "释然音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "jealous": {
+            "type": "string",
+            "description": "嫉妒音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "weary": {
+            "type": "string",
+            "description": "厌倦音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "anxious": {
+            "type": "string",
+            "description": "忐忑音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "affectionate": {
+            "type": "string",
+            "description": "动情音色/标签",
+            "default": "",
+            "hint": "可填写该供应商有效的 voice id；留空则回退到平静/默认音色。MiMo 即使留空也会根据 emotion 自动添加中文情绪标签。"
+          },
+          "sing": {
+            "type": "string",
+            "description": "唱歌音色/标签",
+            "default": "",
+            "hint": "通用默认留空，避免其他供应商误把“唱歌”当 voice id。MiMo 会在 emotion=sing 时自动添加“唱歌”标签。其他供应商如支持唱歌，可手动填写有效 voice id/标签。"
           }
-        }
+        },
+        "hint": "通用情绪到音色映射。请填写当前供应商有效的 voice id；默认留空以避免把 MiMo 中文标签误传给其他供应商。MiMo 会在 voice_map 留空时根据 emotion 自动添加中文情绪/唱歌标签。"
       },
       "speed_map": {
         "type": "object",
@@ -587,25 +1021,120 @@
         "items": {
           "neutral": {
             "type": "float",
-            "description": "中性语速",
-            "default": 1.0
+            "description": "平静语速",
+            "default": 1.0,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
           },
           "happy": {
             "type": "float",
             "description": "开心语速",
-            "default": 1.2
+            "default": 1.15,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
           },
           "sad": {
             "type": "float",
-            "description": "难过语速",
-            "default": 0.85
+            "description": "悲伤语速",
+            "default": 0.9,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
           },
           "angry": {
             "type": "float",
-            "description": "生气语速",
-            "default": 1.1
+            "description": "愤怒语速",
+            "default": 1.15,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "fear": {
+            "type": "float",
+            "description": "恐惧语速",
+            "default": 1.05,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "surprise": {
+            "type": "float",
+            "description": "惊讶语速",
+            "default": 1.12,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "excited": {
+            "type": "float",
+            "description": "兴奋语速",
+            "default": 1.2,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "wronged": {
+            "type": "float",
+            "description": "委屈语速",
+            "default": 0.92,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "cold": {
+            "type": "float",
+            "description": "冷漠语速",
+            "default": 0.95,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "melancholy": {
+            "type": "float",
+            "description": "怅然语速",
+            "default": 0.9,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "gratified": {
+            "type": "float",
+            "description": "欣慰语速",
+            "default": 1.0,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "helpless": {
+            "type": "float",
+            "description": "无奈语速",
+            "default": 0.95,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "guilty": {
+            "type": "float",
+            "description": "愧疚语速",
+            "default": 0.92,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "relieved": {
+            "type": "float",
+            "description": "释然语速",
+            "default": 1.0,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "jealous": {
+            "type": "float",
+            "description": "嫉妒语速",
+            "default": 1.05,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "weary": {
+            "type": "float",
+            "description": "厌倦语速",
+            "default": 0.9,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "anxious": {
+            "type": "float",
+            "description": "忐忑语速",
+            "default": 1.08,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "affectionate": {
+            "type": "float",
+            "description": "动情语速",
+            "default": 0.95,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
+          },
+          "sing": {
+            "type": "float",
+            "description": "唱歌语速",
+            "default": 1.0,
+            "hint": "1.0 为默认；MiMo 可能忽略语速。"
           }
-        }
+        },
+        "hint": "通用情绪到语速映射。1.0 表示默认；部分供应商（包括 MiMo）可能忽略语速参数。"
       }
     }
   }

--- a/core/config.py
+++ b/core/config.py
@@ -44,6 +44,7 @@ from .constants import (
     DEFAULT_TEXT_VOICE_ENABLE,
     DEFAULT_TTS_PROVIDER,
     DEFAULT_VOICE_OUTPUT_ENABLE,
+    MIMO_STYLE_CATEGORIES,
 )
 
 logger = logging.getLogger(__name__)
@@ -221,6 +222,34 @@ class ConfigManager:
                 sf[k] = v
         engine["siliconflow"] = sf
 
+        mi = engine.get("mimo", {}) or {}
+        # Keep MiMo settings as a first-class provider.  If an older config
+        # stored MiMo credentials under the siliconflow block, migrate them.
+        legacy_is_mimo = str(sf.get("url", "")).rstrip("/") in {
+            "https://token-plan-cn.xiaomimimo.com/v1",
+            "https://api.xiaomimimo.com/v1",
+        } or str(sf.get("model", "")).lower().startswith("mimo-")
+        mi_defaults = {
+            "url": sf.get("url") if legacy_is_mimo else "https://token-plan-cn.xiaomimimo.com/v1",
+            "key": sf.get("key") if legacy_is_mimo else "",
+            "model": sf.get("model") if legacy_is_mimo else "mimo-v2.5-tts",
+            "voice": "mimo_default",
+            "sing_voice": "",
+            "format": sf.get("format", DEFAULT_API_FORMAT),
+            "speed": sf.get("speed", DEFAULT_API_SPEED),
+            "style_prompt": "",
+            "overall_tone": "",
+            "timbre_positioning": "",
+            "persona_accent": "",
+            "dialect": "",
+            "role_play": "",
+            "seed_text": "",
+        }
+        for k, v in mi_defaults.items():
+            if k not in mi:
+                mi[k] = v
+        engine["mimo"] = mi
+
         mm = engine.get("minimax", {}) or {}
         mm_defaults = {
             "url": DEFAULT_MINIMAX_URL,
@@ -271,6 +300,21 @@ class ConfigManager:
                 "请在回复开头添加 [EMO:happy|sad|angry|neutral]，该标记仅供系统解析，不对用户显示。"
             )
         route["marker"] = marker
+
+        # Keep voice_map provider-neutral. MiMo converts emotion/sing keys to
+        # Chinese style tags inside provider_mimo when the map is left empty.
+        route["voice_map"] = route.get("voice_map", {}) or {}
+
+        speed_map = route.get("speed_map", {}) or {}
+        if "sing" not in speed_map:
+            speed_map["sing"] = 1.0
+        route["speed_map"] = speed_map
+
+        keywords = route.get("keywords", {}) or {}
+        if "sing" not in keywords:
+            keywords["sing"] = ["sing", "singing", "唱歌", "唱首歌", "来首歌", "唱", "歌"]
+        route["keywords"] = keywords
+
         self._config["emotion_route"] = route
 
         # Segmented TTS
@@ -381,7 +425,7 @@ class ConfigManager:
     def get_tts_provider(self) -> str:
         engine = self.get("tts_engine", {}) or {}
         provider = str(engine.get("provider", DEFAULT_TTS_PROVIDER)).strip().lower()
-        return provider if provider in {"siliconflow", "minimax"} else DEFAULT_TTS_PROVIDER
+        return provider if provider in {"siliconflow", "minimax", "mimo"} else DEFAULT_TTS_PROVIDER
 
     def is_emotion_route_enabled(self) -> bool:
         return bool((self.get("emotion_route", {}) or {}).get("enable", True))
@@ -436,6 +480,38 @@ class ConfigManager:
                 "gain": 0.0,
             }
 
+        if provider == "mimo":
+            mi = engine.get("mimo", {}) or {}
+            return {
+                "provider": "mimo",
+                "url": str(mi.get("url", "https://api.xiaomimimo.com/v1")).rstrip("/"),
+                "key": str(mi.get("key", "")),
+                "model": str(mi.get("model", "mimo-v2.5-tts")),
+                "voice": str(mi.get("voice", "mimo_default")),
+                "sing_voice": str(mi.get("sing_voice", "")),
+                "format": str(mi.get("format", "mp3")).lower(),
+                "speed": _safe_float(mi.get("speed"), DEFAULT_API_SPEED),
+                "timeout": timeout,
+                "max_retries": max_retries,
+                "default_voice": str(mi.get("voice", "mimo_default")),
+                "voice_id": str(mi.get("voice", "mimo_default")),
+                "style_prompt": str(mi.get("style_prompt", "")),
+                "overall_tone": str(mi.get("overall_tone", "")),
+                "timbre_positioning": str(mi.get("timbre_positioning", "")),
+                "persona_accent": str(mi.get("persona_accent", "")),
+                "dialect": str(mi.get("dialect", "")),
+                "role_play": str(mi.get("role_play", "")),
+                "seed_text": str(mi.get("seed_text", "")),
+                "gain": 0.0,
+                "vol": DEFAULT_MINIMAX_VOL,
+                "pitch": DEFAULT_MINIMAX_PITCH,
+                "emotion": "neutral",
+                "sample_rate": 44100,
+                "bitrate": DEFAULT_MINIMAX_BITRATE,
+                "channel": DEFAULT_MINIMAX_CHANNEL,
+                "subtitle_enable": False,
+            }
+
         sf = engine.get("siliconflow", {}) or {}
         fmt = str(sf.get("format", DEFAULT_API_FORMAT)).lower()
         sr_default = DEFAULT_SAMPLE_RATE_MP3_WAV if fmt in ("mp3", "wav") else DEFAULT_SAMPLE_RATE_OTHER
@@ -458,6 +534,14 @@ class ConfigManager:
             "bitrate": DEFAULT_MINIMAX_BITRATE,
             "channel": DEFAULT_MINIMAX_CHANNEL,
             "subtitle_enable": False,
+        }
+
+    def get_mimo_style_config(self) -> Dict[str, str]:
+        engine = self.get("tts_engine", {}) or {}
+        mi = engine.get("mimo", {}) or {}
+        return {
+            category: str(mi.get(category, "") or "").strip()
+            for category in MIMO_STYLE_CATEGORIES.keys()
         }
 
     # ------------------------------------------------------------------

--- a/core/constants.py
+++ b/core/constants.py
@@ -17,8 +17,35 @@ PLUGIN_DIR = Path(__file__).parent.parent
 CONFIG_FILE = PLUGIN_DIR / "config.json"
 TEMP_DIR = PLUGIN_DIR / "temp"
 
-# Emotion constants
-EMOTIONS: Tuple[str, ...] = ("happy", "sad", "angry", "neutral")
+# Emotion constants - 18 emotions are inferred from dialogue context.
+# 基础情绪 (9种): 开心/悲伤/愤怒/恐惧/惊讶/兴奋/委屈/平静/冷漠
+BASIC_EMOTIONS = ("happy", "sad", "angry", "fear", "surprise", "excited", "wronged", "neutral", "cold")
+# 复合情绪 (9种): 怅然/欣慰/无奈/愧疚/释然/嫉妒/厌倦/忐忑/动情
+COMPLEX_EMOTIONS = ("melancholy", "gratified", "helpless", "guilty", "relieved", "jealous", "weary", "anxious", "affectionate")
+# 特殊功能标签：唱歌仍走同一条路由，但不算“语境情绪”。
+SPECIAL_TAGS = ("sing",)
+
+EMOTIONS: Tuple[str, ...] = BASIC_EMOTIONS + COMPLEX_EMOTIONS + SPECIAL_TAGS
+CONTEXT_EMOTIONS: Tuple[str, ...] = BASIC_EMOTIONS + COMPLEX_EMOTIONS
+
+# These are not context emotions. They are independent MiMo style dimensions
+# that may be configured permanently or overridden temporarily in a user turn.
+MIMO_STYLE_CATEGORIES: Dict[str, Tuple[str, ...]] = {
+    "overall_tone": ("温柔", "高冷", "活泼", "严肃", "慵懒", "俏皮", "深沉", "干练", "凌厉"),
+    "timbre_positioning": ("磁性", "醇厚", "清亮", "空灵", "稚嫩", "苍老", "甜美", "沙哑", "醇雅"),
+    "persona_accent": ("夹子音", "御姐音", "正太音", "大叔音", "台湾腔"),
+    "dialect": ("东北话", "四川话", "河南话", "粤语"),
+    "role_play": ("孙悟空", "林黛玉"),
+}
+MIMO_STYLE_LABEL_TO_CATEGORY: Dict[str, str] = {
+    label: category
+    for category, labels in MIMO_STYLE_CATEGORIES.items()
+    for label in labels
+}
+MIMO_STYLE_HINTS: Dict[str, str] = {
+    category: "/".join(labels)
+    for category, labels in MIMO_STYLE_CATEGORIES.items()
+}
 
 INVISIBLE_CHARS: List[str] = [
     "\ufeff",
@@ -35,23 +62,138 @@ INVISIBLE_CHARS: List[str] = [
 ]
 
 EMOTION_KEYWORDS: Dict[str, Pattern] = {
-    "happy": re.compile(r"(happy|great|awesome|excited|lol|nice)", re.I),
-    "sad": re.compile(r"(sad|sorry|upset|depressed|cry)", re.I),
-    "angry": re.compile(r"(angry|mad|furious|annoyed|rage)", re.I),
+    # \u57fa\u7840\u60c5\u7eea
+    "happy": re.compile(r"(happy|great|awesome|excited|lol|nice|\u5f00\u5fc3|\u9ad8\u5174|\u54c8\u54c8|\u563b\u563b|\u592a\u597d\u4e86|\u68d2|\u597d\u8036)", re.I),
+    "sad": re.compile(r"(sad|sorry|upset|depressed|cry|\u60b2\u4f24|\u96be\u8fc7|\u4f24\u5fc3|\u545c\u545c|\u5509|\u53ef\u60dc|\u5fc3\u75bc)", re.I),
+    "angry": re.compile(r"(angry|mad|furious|annoyed|rage|\u6124\u6012|\u751f\u6c14|\u6c14\u6b7b|\u53ef\u6076|\u70e6\u6b7b\u4e86|\u8ba8\u538c)", re.I),
+    "neutral": re.compile(r"(neutral|calm|normal|\u5e73\u9759|\u51b7\u9759|\u6b63\u5e38|\u5ba2\u89c2)", re.I),
+    "surprise": re.compile(r"(surprise|wow|omg|\u60ca\u8bb6|\u54c7|\u5929\u54ea|\u4e0d\u4f1a\u5427|\u771f\u7684\u5417|\u6211\u53bb|\u9707\u60ca)", re.I),
+    "fear": re.compile(r"(fear|scared|afraid|terrified|\u5bb3\u6015|\u6050\u60e7|\u5413\u6b7b|\u597d\u53ef\u6015|\u745f\u745f\u53d1\u6296)", re.I),
+    "excited": re.compile(r"(excited|thrilled|\u5174\u594b|\u6fc0\u52a8|\u592a\u68d2\u4e86|\u597d\u6fc0\u52a8|\u51b2\u51b2\u51b2)", re.I),
+    "wronged": re.compile(r"(wronged|mistaken|\u59d4\u5c48|\u51a4\u6789|\u597d\u59d4\u5c48|\u5624\u5624\u5624)", re.I),
+    "cold": re.compile(r"(cold|indifferent|\u51b7\u6f20|\u51b7\u6de1|\u65e0\u6240\u8c13|\u968f\u4fbf)", re.I),
+    # \u590d\u5408\u60c5\u7eea
+    "melancholy": re.compile(r"(melancholy|wistful|\u6005\u7136|\u82e5\u6709\u6240\u601d|\u611f\u6168|\u60c6\u6005)", re.I),
+    "gratified": re.compile(r"(gratified|pleased|\u6b23\u6170|\u611f\u5230\u5b89\u6170|\u503c\u5f97\u4e86)", re.I),
+    "helpless": re.compile(r"(helpless|\u65e0\u5948|\u65e0\u53ef\u5948\u4f55|\u6ca1\u529e\u6cd5|\u53ea\u80fd\u8fd9\u6837)", re.I),
+    "guilty": re.compile(r"(guilty|sorry|\u6127\u759a|\u62b1\u6b49|\u5bf9\u4e0d\u8d77|\u4e0d\u597d\u610f\u601d)", re.I),
+    "relieved": re.compile(r"(relieved|\u91ca\u7136|\u653e\u5fc3\u4e86|\u677e\u4e86\u53e3\u6c14|\u7ec8\u4e8e)", re.I),
+    "jealous": re.compile(r"(jealous|envious|\u5ac9\u5992|\u7fa1\u6155|\u597d\u7fa1\u6155|\u9178\u4e86)", re.I),
+    "weary": re.compile(r"(weary|tired|\u538c\u5026|\u75b2\u60eb|\u7d2f\u4e86|\u591f\u4e86)", re.I),
+    "anxious": re.compile(r"(anxious|nervous|\u5fd0\u5fd1|\u7d27\u5f20|\u4e0d\u5b89|\u62c5\u5fc3)", re.I),
+    "affectionate": re.compile(r"(affectionate|loving|\u52a8\u60c5|\u6df1\u60c5|\u611f\u52a8|\u7231)", re.I),
+    # \u6574\u4f53\u8bed\u8c03
+    "gentle": re.compile(r"(gentle|tender|\u6e29\u67d4|\u8f7b\u58f0|\u67d4\u548c|\u6162\u6162|\u8f7b\u67d4)", re.I),
+    "cool": re.compile(r"(cool|aloof|\u9ad8\u51b7|\u51b7\u6de1|\u50b2\u5a07|\u4e0d\u5c51)", re.I),
+    "lively": re.compile(r"(lively|cheerful|\u6d3b\u6cfc|\u5f00\u6717|\u5143\u6c14|\u6d3b\u529b)", re.I),
+    "serious": re.compile(r"(serious|solemn|\u4e25\u8083|\u8ba4\u771f|\u6b63\u7ecf|\u91cd\u8981|\u90d1\u91cd)", re.I),
+    "lazy": re.compile(r"(lazy|idle|\u6175\u61d2|\u61d2\u6563|\u56f0|\u4e0d\u60f3\u52a8)", re.I),
+    "playful": re.compile(r"(playful|mischievous|\u4fcf\u76ae|\u6d3b\u6cfc|\u8c03\u76ae|\u563f\u563f|\u76ae\u4e00\u4e0b)", re.I),
+    "deep": re.compile(r"(deep|profound|\u6df1\u6c89|\u6c89\u7a33|\u4f4e\u6c89|\u6ca7\u6851)", re.I),
+    "capable": re.compile(r"(capable|efficient|\u5e72\u7ec3|\u7cbe\u660e|\u5229\u843d|\u679c\u65ad)", re.I),
+    "sharp": re.compile(r"(sharp|keen|\u51cc\u5389|\u9510\u5229|\u7280\u5229|\u5c16\u9510)", re.I),
+    # \u97f3\u8272\u5b9a\u4f4d
+    "magnetic": re.compile(r"(magnetic|charming|\u78c1\u6027|\u8ff7\u4eba|\u6709\u9b45\u529b)", re.I),
+    "mellow": re.compile(r"(mellow|rich|\u9187\u539a|\u6d53\u90c1|\u6d51\u539a)", re.I),
+    "clear": re.compile(r"(clear|bright|\u6e05\u4eae|\u6e05\u6670|\u660e\u4eae|\u6e05\u6f88)", re.I),
+    "ethereal": re.compile(r"(ethereal|airy|\u7a7a\u7075|\u98d8\u6e3a|\u4ed9\u6c14|\u68a6\u5e7b)", re.I),
+    "young": re.compile(r"(young|childish|\u7a1a\u5ae9|\u5e74\u8f7b|\u7ae5\u58f0|\u53ef\u7231)", re.I),
+    "old": re.compile(r"(old|elderly|\u82cd\u8001|\u5e74\u8fc8|\u6ca7\u6851|\u8001\u6210)", re.I),
+    "sweet": re.compile(r"(sweet|\u751c\u7f8e|\u751c\u871c|\u751c|\u597d\u751c)", re.I),
+    "hoarse": re.compile(r"(hoarse|raspy|\u6c99\u54d1|\u5636\u54d1|\u54d1)", re.I),
+    "elegant": re.compile(r"(elegant|refined|\u9187\u96c5|\u4f18\u96c5|\u9ad8\u96c5|\u7aef\u5e84)", re.I),
+    # \u7279\u6b8a\u6807\u7b7e
+    "sing": re.compile(r"(sing|singing|\u5531\u6b4c|\u5531|\u6b4c)", re.I),
 }
 
 EMOTION_SYNONYMS: Dict[str, Set[str]] = {
-    "happy": {"happy", "joy", "joyful", "cheerful", "excited", "positive"},
-    "sad": {"sad", "sorrow", "depressed", "down", "unhappy", "upset"},
-    "angry": {"angry", "mad", "furious", "annoyed", "irritated", "rage"},
-    "neutral": {"neutral", "calm", "normal", "objective", "ok", "fine", "confused"},
+    # \u57fa\u7840\u60c5\u7eea
+    "happy": {"happy", "joy", "joyful", "cheerful", "excited", "positive", "\u5f00\u5fc3", "\u9ad8\u5174", "\u597d\u8036"},
+    "sad": {"sad", "sorrow", "depressed", "down", "unhappy", "upset", "\u60b2\u4f24", "\u96be\u8fc7", "\u5fc3\u75bc"},
+    "angry": {"angry", "mad", "furious", "annoyed", "irritated", "rage", "\u6124\u6012", "\u751f\u6c14", "\u8ba8\u538c"},
+    "neutral": {"neutral", "calm", "normal", "objective", "ok", "fine", "\u5e73\u9759", "\u51b7\u9759", "\u6b63\u5e38"},
+    "surprise": {"surprise", "amazed", "astonished", "wow", "omg", "\u60ca\u8bb6", "\u54c7", "\u6211\u53bb"},
+    "fear": {"fear", "scared", "afraid", "terrified", "\u5bb3\u6015", "\u6050\u60e7", "\u745f\u745f\u53d1\u6296"},
+    "excited": {"excited", "thrilled", "\u5174\u594b", "\u6fc0\u52a8", "\u597d\u6fc0\u52a8", "\u51b2\u51b2\u51b2"},
+    "wronged": {"wronged", "mistaken", "\u59d4\u5c48", "\u51a4\u6789", "\u597d\u59d4\u5c48", "\u5624\u5624\u5624"},
+    "cold": {"cold", "indifferent", "\u51b7\u6f20", "\u51b7\u6de1", "\u65e0\u6240\u8c13", "\u968f\u4fbf"},
+    # \u590d\u5408\u60c5\u7eea
+    "melancholy": {"melancholy", "wistful", "\u6005\u7136", "\u82e5\u6709\u6240\u601d", "\u611f\u6168", "\u60c6\u6005"},
+    "gratified": {"gratified", "pleased", "\u6b23\u6170", "\u611f\u5230\u5b89\u6170", "\u503c\u5f97\u4e86"},
+    "helpless": {"helpless", "\u65e0\u5948", "\u65e0\u53ef\u5948\u4f55", "\u6ca1\u529e\u6cd5", "\u53ea\u80fd\u8fd9\u6837"},
+    "guilty": {"guilty", "sorry", "\u6127\u759a", "\u62b1\u6b49", "\u5bf9\u4e0d\u8d77", "\u4e0d\u597d\u610f\u601d"},
+    "relieved": {"relieved", "\u91ca\u7136", "\u653e\u5fc3\u4e86", "\u677e\u4e86\u53e3\u6c14", "\u7ec8\u4e8e"},
+    "jealous": {"jealous", "envious", "\u5ac9\u5992", "\u7fa1\u6155", "\u597d\u7fa1\u6155", "\u9178\u4e86"},
+    "weary": {"weary", "tired", "\u538c\u5026", "\u75b2\u60eb", "\u7d2f\u4e86", "\u591f\u4e86"},
+    "anxious": {"anxious", "nervous", "\u5fd0\u5fd1", "\u7d27\u5f20", "\u4e0d\u5b89", "\u62c5\u5fc3"},
+    "affectionate": {"affectionate", "loving", "\u52a8\u60c5", "\u6df1\u60c5", "\u611f\u52a8", "\u7231"},
+    # \u6574\u4f53\u8bed\u8c03
+    "gentle": {"gentle", "tender", "\u6e29\u67d4", "\u8f7b\u58f0", "\u67d4\u548c", "\u8f7b\u67d4"},
+    "cool": {"cool", "aloof", "\u9ad8\u51b7", "\u51b7\u6de1", "\u50b2\u5a07", "\u4e0d\u5c51"},
+    "lively": {"lively", "cheerful", "\u6d3b\u6cfc", "\u5f00\u6717", "\u5143\u6c14", "\u6d3b\u529b"},
+    "serious": {"serious", "solemn", "\u4e25\u8083", "\u8ba4\u771f", "\u6b63\u7ecf", "\u90d1\u91cd"},
+    "lazy": {"lazy", "idle", "\u6175\u61d2", "\u61d2\u6563", "\u56f0", "\u4e0d\u60f3\u52a8"},
+    "playful": {"playful", "mischievous", "\u4fcf\u76ae", "\u8c03\u76ae", "\u563f\u563f", "\u76ae\u4e00\u4e0b"},
+    "deep": {"deep", "profound", "\u6df1\u6c89", "\u6c89\u7a33", "\u4f4e\u6c89", "\u6ca7\u6851"},
+    "capable": {"capable", "efficient", "\u5e72\u7ec3", "\u7cbe\u660e", "\u5229\u843d", "\u679c\u65ad"},
+    "sharp": {"sharp", "keen", "\u51cc\u5389", "\u9510\u5229", "\u7280\u5229", "\u5c16\u9510"},
+    # \u97f3\u8272\u5b9a\u4f4d
+    "magnetic": {"magnetic", "charming", "\u78c1\u6027", "\u8ff7\u4eba", "\u6709\u9b45\u529b"},
+    "mellow": {"mellow", "rich", "\u9187\u539a", "\u6d53\u90c1", "\u6d51\u539a"},
+    "clear": {"clear", "bright", "\u6e05\u4eae", "\u6e05\u6670", "\u660e\u4eae", "\u6e05\u6f88"},
+    "ethereal": {"ethereal", "airy", "\u7a7a\u7075", "\u98d8\u6e3a", "\u4ed9\u6c14", "\u68a6\u5e7b"},
+    "young": {"young", "childish", "\u7a1a\u5ae9", "\u5e74\u8f7b", "\u7ae5\u58f0", "\u53ef\u7231"},
+    "old": {"old", "elderly", "\u82cd\u8001", "\u5e74\u8fc8", "\u6ca7\u6851", "\u8001\u6210"},
+    "sweet": {"sweet", "\u751c\u7f8e", "\u751c\u871c", "\u751c", "\u597d\u751c"},
+    "hoarse": {"hoarse", "raspy", "\u6c99\u54d1", "\u5636\u54d1", "\u54d1"},
+    "elegant": {"elegant", "refined", "\u9187\u96c5", "\u4f18\u96c5", "\u9ad8\u96c5", "\u7aef\u5e84"},
+    # \u7279\u6b8a\u6807\u7b7e
+    "sing": {"sing", "singing", "\u5531\u6b4c", "\u5531", "\u6b4c"},
 }
 
 EMOTION_PREFERENCE_MAP: Dict[str, str] = {
-    "sad": "neutral",
-    "angry": "neutral",
+    # \u57fa\u7840\u60c5\u7eea - \u4fdd\u6301\u539f\u6837
     "happy": "happy",
+    "sad": "sad",
+    "angry": "angry",
     "neutral": "neutral",
+    "surprise": "surprise",
+    "fear": "fear",
+    "excited": "excited",
+    "wronged": "wronged",
+    "cold": "cold",
+    # \u590d\u5408\u60c5\u7eea - \u4fdd\u6301\u539f\u6837
+    "melancholy": "melancholy",
+    "gratified": "gratified",
+    "helpless": "helpless",
+    "guilty": "guilty",
+    "relieved": "relieved",
+    "jealous": "jealous",
+    "weary": "weary",
+    "anxious": "anxious",
+    "affectionate": "affectionate",
+    # \u6574\u4f53\u8bed\u8c03 - \u4fdd\u6301\u539f\u6837
+    "gentle": "gentle",
+    "cool": "cool",
+    "lively": "lively",
+    "serious": "serious",
+    "lazy": "lazy",
+    "playful": "playful",
+    "deep": "deep",
+    "capable": "capable",
+    "sharp": "sharp",
+    # \u97f3\u8272\u5b9a\u4f4d - \u4fdd\u6301\u539f\u6837
+    "magnetic": "magnetic",
+    "mellow": "mellow",
+    "clear": "clear",
+    "ethereal": "ethereal",
+    "young": "young",
+    "old": "old",
+    "sweet": "sweet",
+    "hoarse": "hoarse",
+    "elegant": "elegant",
+    # \u7279\u6b8a\u6807\u7b7e
+    "sing": "sing",
 }
 
 # Audio constants

--- a/core/marker.py
+++ b/core/marker.py
@@ -24,51 +24,52 @@ from .constants import (
 class EmotionMarkerProcessor:
     """
     情绪标记处理器。
-    
+
     负责：
     1. 从文本中解析情绪标记（如 [EMO:happy]）
     2. 清理文本中的情绪标记
     3. 归一化情绪标签到标准四选一
     """
-    
+
     def __init__(self, tag: str = DEFAULT_EMO_MARKER_TAG, enabled: bool = True):
         """
         初始化情绪标记处理器。
-        
+
         Args:
             tag: 情绪标记标签（如 "EMO"）
             enabled: 是否启用标记处理
         """
         self.tag = tag
         self.enabled = enabled
-        
+
         # 编译正则表达式
         self._compile_patterns()
-    
+
     def _compile_patterns(self) -> None:
         """编译所有需要的正则表达式。"""
         try:
             escaped_tag = re.escape(self.tag)
-            
-            # 严格匹配：[EMO:happy] 格式，标签为四选一
+
+            labels = "|".join(re.escape(label) for label in EMOTIONS)
+            # 严格匹配：[EMO:happy] 格式，标签为当前支持的 18 种情绪/特殊标签
             self._marker_strict_re: Optional[Pattern] = re.compile(
-                rf"\[\s*{escaped_tag}\s*:\s*(happy|sad|angry|neutral)\s*\]",
+                rf"\[\s*{escaped_tag}\s*:\s*({labels})\s*\]",
                 re.I
             )
-            
+
             # 宽松匹配任意形态头部标记（用于清理）
             # 允许":[label]"可缺省label，接受半/全角冒号及连字符
             self._marker_any_re: Optional[Pattern] = re.compile(
                 rf"^[\s\ufeff]*[\[\(【]\s*{escaped_tag}\s*(?:[:\uff1a-]\s*[a-z]*)?\s*[\]\)】]",
                 re.I
             )
-            
+
             # 头部 token：支持 [EMO] / [EMO:] / 【EMO：】 / emo / emo:happy / 等
             self._head_token_re: Optional[Pattern] = re.compile(
-                rf"^[\s\ufeff]*(?:[\[\(【]\s*{escaped_tag}\s*(?:[:\uff1a-]\s*(?P<lbl>happy|sad|angry|neutral))?\s*[\]\)】]|(?:{escaped_tag}|emo)\s*(?:[:\uff1a-]\s*(?P<lbl2>happy|sad|angry|neutral))?)\s*[,，。:\uff1a-]*\s*",
+                rf"^[\s\ufeff]*(?:[\[\(【]\s*{escaped_tag}\s*(?:[:\uff1a-]\s*(?P<lbl>{labels}))?\s*[\]\)】]|(?:{escaped_tag}|emo)\s*(?:[:\uff1a-]\s*(?P<lbl2>{labels}))?)\s*[,，。:\uff1a-]*\s*",
                 re.I
             )
-            
+
             # 头部 token（英文任意标签）：如 [EMO:confused]
             self._head_anylabel_re: Optional[Pattern] = re.compile(
                 rf"^[\s\ufeff]*[\[\(【]\s*{escaped_tag}\s*[:\uff1a-]\s*(?P<raw>[a-z][a-z_-]*)\s*[\]\)】]",
@@ -80,7 +81,7 @@ class EmotionMarkerProcessor:
                 rf'(^|\n)\s*[\[\(【]\s*{escaped_tag}\s*(?:[:：-]\s*[^\]\)】\n]+)?\s*[\]\)】]\s*',
                 re.I
             )
-            
+
             # 激进清理 - 句中：直接全局删除
             self._marker_mid_visible_re: Optional[Pattern] = re.compile(
                 rf'[\[\(【]\s*{escaped_tag}\s*(?:[:：-]\s*[^\]\)】\n]+)?\s*[\]\)】]',
@@ -90,7 +91,7 @@ class EmotionMarkerProcessor:
             # 清理多余空白
             self._cleanup_spaces_re: Optional[Pattern] = re.compile(r'[ \t]{2,}')
             self._cleanup_newlines_re: Optional[Pattern] = re.compile(r'\n{3,}')
-            
+
         except Exception as e:
             logger.warning(f"EmotionMarkerProcessor: pattern compile failed: {e}", exc_info=True)
             self._marker_strict_re = None
@@ -101,14 +102,14 @@ class EmotionMarkerProcessor:
             self._marker_mid_visible_re = None
             self._cleanup_spaces_re = None
             self._cleanup_newlines_re = None
-    
+
     def normalize_text(self, text: str) -> str:
         """
         移除不可见字符与 BOM。
-        
+
         Args:
             text: 原始文本
-            
+
         Returns:
             清理后的文本
         """
@@ -117,41 +118,41 @@ class EmotionMarkerProcessor:
         for ch in INVISIBLE_CHARS:
             text = text.replace(ch, "")
         return text
-    
+
     def normalize_label(self, label: Optional[str]) -> Optional[str]:
         """
         将任意英文/中文情绪词映射到四选一。
-        
+
         Args:
             label: 原始情绪标签
-            
+
         Returns:
             归一化后的情绪标签（happy/sad/angry/neutral）或 None
         """
         if not label:
             return None
-        
+
         lbl = label.strip().lower()
-        
+
         for emotion, synonyms in EMOTION_SYNONYMS.items():
             if lbl in synonyms:
                 return emotion
-        
+
         return None
-    
+
     def strip_head(self, text: str) -> Tuple[str, Optional[str]]:
         """
         从文本开头剥离情绪标记。
-        
+
         Args:
             text: 原始文本
-            
+
         Returns:
             (清理后的文本, 解析到的情绪或 None)
         """
         if not text:
             return text, None
-        
+
         # 优先用宽松的头部匹配（限定四选一）
         if self._head_token_re:
             m = self._head_token_re.match(text)
@@ -161,7 +162,7 @@ class EmotionMarkerProcessor:
                     label = None  # type: ignore
                 cleaned = self._head_token_re.sub("", text, count=1)
                 return cleaned.strip(), label if label in EMOTIONS else None
-        
+
         # 其次：捕获任意英文标签，再做同义词归一化
         if self._head_anylabel_re:
             m2 = self._head_anylabel_re.match(text)
@@ -170,26 +171,26 @@ class EmotionMarkerProcessor:
                 label = self.normalize_label(raw)
                 cleaned = self._head_anylabel_re.sub("", text, count=1)
                 return cleaned.strip(), label
-        
+
         # 最后：去掉任何形态头部标记（即便无法识别标签含义也移除）
         if self._marker_any_re and text.lstrip().startswith(("[", "【", "(")):
             cleaned = self._marker_any_re.sub("", text, count=1)
             return cleaned.strip(), None
-        
+
         return text, None
-    
+
     def strip_head_many(self, text: str) -> Tuple[str, Optional[str]]:
         """
         连续剥离多枚开头的情绪标记，并清理全文中残留的任何可见标记。
-        
+
         Args:
             text: 原始文本
-            
+
         Returns:
             (清理后文本, 最后一次解析到的情绪)
         """
         last_label: Optional[str] = None
-        
+
         # 1. 优先清理头部，并提取情绪
         while True:
             cleaned, label = self.strip_head(text)
@@ -198,26 +199,26 @@ class EmotionMarkerProcessor:
             if cleaned == text:
                 break
             text = cleaned
-        
+
         # 2. 全局清理任何位置的残留标记（不提取情绪，仅清理）
         try:
             if self._marker_strict_re:
                 text = self._marker_strict_re.sub("", text)
         except Exception as e:
             logger.debug(f"Failed to strip residual markers: {e}")
-        
+
         return text.strip(), last_label
-    
+
     def strip_all_visible_markers(self, text: str) -> str:
         """
         更激进地移除文本任意位置的隐藏情绪标记。
-        
+
         匹配：[EMO:happy] / 【EMO：sad】 / (EMO:angry) 等
         无论在开头、行首或句中均清理。
-        
+
         Args:
             text: 原始文本
-            
+
         Returns:
             清理后的文本
         """
@@ -226,37 +227,37 @@ class EmotionMarkerProcessor:
             if self._marker_head_visible_re:
                 def _head_sub(m: re.Match) -> str:
                     return "\n" if m.group(1) == "\n" else ""
-                
+
                 text = self._marker_head_visible_re.sub(_head_sub, text)
-            
+
             # 2) 句中：直接全局删除
             if self._marker_mid_visible_re:
                 text = self._marker_mid_visible_re.sub('', text)
-            
+
             # 3) 清理多余空白
             if self._cleanup_spaces_re:
                 text = self._cleanup_spaces_re.sub(' ', text)
             if self._cleanup_newlines_re:
                 text = self._cleanup_newlines_re.sub('\n\n', text)
-            
+
             return text.strip()
         except Exception as e:
             logger.error(f"Failed to strip all visible markers: {e}", exc_info=True)
             return text
-    
+
     def extract_emotion(self, text: str) -> Optional[str]:
         """
         从文本中提取情绪标签（不修改文本）。
-        
+
         Args:
             text: 原始文本
-            
+
         Returns:
             提取到的情绪标签或 None
         """
         if not text or not self._marker_strict_re:
             return None
-        
+
         m = self._marker_strict_re.search(text)
         if m:
             label = m.group(1).lower()
@@ -264,42 +265,40 @@ class EmotionMarkerProcessor:
                 return label
         else:
             logger.debug("No strict emotion marker found in text.")
-        
+
         return None
-    
+
     def build_injection_instruction(self) -> str:
         """
         构建要注入到 LLM 系统提示中的情绪标记指令。
-        
+
         Returns:
             情绪标记指令文本
         """
         return (
-            f"请在每次回复的最开头只输出一个隐藏情绪标记，格式严格为："
-            f"[{self.tag}:happy] 或 [{self.tag}:sad] 或 [{self.tag}:angry] 或 [{self.tag}:neutral]。"
-            "必须四选一；若无法判断请选择 neutral。该标记仅供系统解析，"
-            "输出后立刻继续正常作答，不要解释或复述该标记。"
-            "如你想到其它词，请映射到以上四类：happy(开心/喜悦/兴奋)、sad(伤心/难过/沮丧/upset)、"
-            "angry(生气/愤怒/恼火/furious)、neutral(平静/普通/困惑/confused)。"
+            f"请在每次回复的最开头只输出一个隐藏情绪标记，格式严格为：[{self.tag}:情绪key]。"
+            "情绪 key 只能从以下列表选择：happy/sad/angry/fear/surprise/excited/wronged/neutral/cold/"
+            "melancholy/gratified/helpless/guilty/relieved/jealous/weary/anxious/affectionate。"
+            "若无法判断请选择 neutral。该标记仅供系统解析，输出后立刻继续正常作答，不要解释或复述该标记。"
         )
-    
+
     def is_marker_present(self, system_prompt: str, prompt: str) -> bool:
         """
         检查提示中是否已存在情绪标记标签。
-        
+
         Args:
             system_prompt: 系统提示
             prompt: 用户提示
-            
+
         Returns:
             如果已存在标记返回 True
         """
         return (self.tag in system_prompt) or (self.tag in prompt)
-    
+
     def update_config(self, tag: str, enabled: bool) -> None:
         """
         更新配置并重新编译正则。
-        
+
         Args:
             tag: 新的情绪标记标签
             enabled: 是否启用

--- a/core/segmented_tts.py
+++ b/core/segmented_tts.py
@@ -48,11 +48,11 @@ class SegmentedTTSResult:
     speed: float = 1.0
     success: bool = False
     error: str = ""
-    
+
     @property
     def successful_segments(self) -> List[SegmentTTSResult]:
         return [s for s in self.segments if s.success]
-    
+
     @property
     def total_duration(self) -> float:
         return sum(s.duration_seconds for s in self.segments if s.success)
@@ -61,12 +61,12 @@ class SegmentedTTSResult:
 async def get_audio_duration(audio_path: Path) -> float:
     """
     获取音频文件时长（秒）。
-    
+
     使用 ffprobe 获取音频时长。如果失败则返回估算值。
     """
     try:
         import subprocess
-        
+
         def _get_duration():
             try:
                 result = subprocess.run(
@@ -85,11 +85,11 @@ async def get_audio_duration(audio_path: Path) -> float:
             except Exception as e:
                 logger.warning(f"ffprobe failed: {e}")
             return 0.0
-        
+
         duration = await asyncio.to_thread(_get_duration)
         if duration > 0:
             return duration
-        
+
         # 备选：根据文件大小估算（假设 mp3 128kbps）
         # 128kbps = 16KB/s
         try:
@@ -99,9 +99,9 @@ async def get_audio_duration(audio_path: Path) -> float:
             return estimated
         except Exception:
             pass
-        
+
         return 3.0  # 默认假设 3 秒
-        
+
     except Exception as e:
         logger.warning(f"get_audio_duration failed: {e}")
         return 3.0
@@ -110,11 +110,11 @@ async def get_audio_duration(audio_path: Path) -> float:
 class SegmentedTTSProcessor:
     """
     分段 TTS 处理器。
-    
+
     将长文本分段后逐条生成语音并发送。
     支持固定间隔和自适应间隔两种模式。
     """
-    
+
     def __init__(
         self,
         tts_processor: TTSProcessor,
@@ -127,7 +127,7 @@ class SegmentedTTSProcessor:
     ):
         """
         初始化分段 TTS 处理器。
-        
+
         Args:
             tts_processor: TTS 处理器实例
             splitter: 文本分段器（可选，不提供则自动创建）
@@ -146,7 +146,7 @@ class SegmentedTTSProcessor:
         self.fixed_interval = fixed_interval
         self.adaptive_buffer = adaptive_buffer
         self.max_segments = max_segments
-    
+
     async def process_and_send(
         self,
         text: str,
@@ -155,45 +155,54 @@ class SegmentedTTSProcessor:
     ) -> SegmentedTTSResult:
         """
         处理文本并逐条发送语音。
-        
+
         Args:
             text: 待处理文本
             session_state: 会话状态
             send_func: 发送函数，接收音频路径，返回是否成功
-            
+
         Returns:
             分段 TTS 结果
         """
         result = SegmentedTTSResult()
-        
+
         try:
             # 1. 分段
             segments = self.splitter.split(text)
             if not segments:
                 result.error = "no segments after splitting"
                 return result
-            
+
             logger.info(f"SegmentedTTS: processing {len(segments)} segment(s)")
-            
+
             # 2. 确定统一的情绪/音色/语速（基于整段文本）
             emotion = self.tts_processor.determine_emotion(session_state, text)
-            voice_key, voice_uri = self.tts_processor.pick_voice_for_emotion(emotion)
+            style_overrides = session_state.consume_pending_style_overrides()
+            pending_voice = session_state.consume_pending_voice()
+            if pending_voice:
+                voice_key, voice_uri = pending_voice, pending_voice
+            else:
+                voice_key, voice_uri = self.tts_processor.pick_voice_for_emotion(emotion)
             speed = self.tts_processor.get_speed_for_emotion(emotion)
-            
+
             if not voice_uri:
-                result.error = f"no voice available for emotion: {emotion}"
-                return result
-            
+                default_voice = str(getattr(self.tts_processor.tts, "voice", "") or getattr(self.tts_processor.tts, "voice_id", "") or "").strip()
+                if default_voice:
+                    voice_key, voice_uri = "default", default_voice
+                else:
+                    result.error = f"no voice available for emotion: {emotion}"
+                    return result
+
             result.emotion = emotion
             result.voice = voice_key
             result.speed = speed
-            
+
             logger.info(f"SegmentedTTS: unified emotion={emotion}, voice={voice_key}, speed={speed}")
-            
+
             # 3. 逐段处理并发送
             for i, segment in enumerate(segments):
                 seg_result = SegmentTTSResult(segment=segment)
-                
+
                 try:
                     # 生成音频
                     audio_path = await self.tts_processor.generate_audio(
@@ -201,55 +210,56 @@ class SegmentedTTSProcessor:
                         voice_uri,
                         speed,
                         emotion=emotion,
+                        style_overrides=style_overrides,
                     )
-                    
+
                     if not audio_path:
                         seg_result.error = "audio generation failed"
                         result.segments.append(seg_result)
                         continue
-                    
+
                     seg_result.audio_path = audio_path
-                    
+
                     # 获取音频时长
                     duration = await get_audio_duration(audio_path)
                     seg_result.duration_seconds = duration
-                    
+
                     # 发送
                     norm_path = self.tts_processor.normalize_audio_path(audio_path)
                     send_success = await send_func(Path(norm_path))
-                    
+
                     if send_success:
                         seg_result.success = True
                         logger.info(f"SegmentedTTS: segment {i+1}/{len(segments)} sent, duration={duration:.2f}s")
                     else:
                         seg_result.error = "send failed"
                         logger.warning(f"SegmentedTTS: segment {i+1}/{len(segments)} send failed")
-                    
+
                 except Exception as e:
                     seg_result.error = str(e)
                     logger.error(f"SegmentedTTS: segment {i+1} processing error: {e}")
-                
+
                 result.segments.append(seg_result)
-                
+
                 # 如果不是最后一段，等待间隔
                 if i < len(segments) - 1:
                     wait_time = self._calculate_interval(seg_result)
                     logger.info(f"SegmentedTTS: waiting {wait_time:.2f}s before next segment")
                     await asyncio.sleep(wait_time)
-            
+
             # 4. 更新会话状态
             if result.successful_segments:
                 result.success = True
                 session_state.last_ts = time.time()
                 session_state.last_emotion = emotion
                 session_state.last_voice = voice_key
-            
+
         except Exception as e:
             result.error = str(e)
             logger.error(f"SegmentedTTS: process_and_send failed: {e}", exc_info=True)
-        
+
         return result
-    
+
     async def process_only(
         self,
         text: str,
@@ -257,52 +267,62 @@ class SegmentedTTSProcessor:
     ) -> SegmentedTTSResult:
         """
         仅处理文本生成音频，不发送。
-        
+
         返回所有分段的音频路径列表，由调用者负责发送。
-        
+
         Args:
             text: 待处理文本
             session_state: 会话状态
-            
+
         Returns:
             分段 TTS 结果（包含所有音频路径）
         """
         result = SegmentedTTSResult()
-        
+
         try:
             # 1. 分段
             segments = self.splitter.split(text)
             if not segments:
                 result.error = "no segments after splitting"
                 return result
-            
+
             logger.info(f"SegmentedTTS: processing {len(segments)} segment(s)")
-            
+
             # 2. 确定统一的情绪/音色/语速
             emotion = self.tts_processor.determine_emotion(session_state, text)
-            voice_key, voice_uri = self.tts_processor.pick_voice_for_emotion(emotion)
+            style_overrides = session_state.consume_pending_style_overrides()
+            pending_voice = session_state.consume_pending_voice()
+            if pending_voice:
+                voice_key, voice_uri = pending_voice, pending_voice
+            else:
+                voice_key, voice_uri = self.tts_processor.pick_voice_for_emotion(emotion)
             speed = self.tts_processor.get_speed_for_emotion(emotion)
-            
+
             if not voice_uri:
-                result.error = f"no voice available for emotion: {emotion}"
-                return result
-            
+                default_voice = str(getattr(self.tts_processor.tts, "voice", "") or getattr(self.tts_processor.tts, "voice_id", "") or "").strip()
+                if default_voice:
+                    voice_key, voice_uri = "default", default_voice
+                else:
+                    result.error = f"no voice available for emotion: {emotion}"
+                    return result
+
             result.emotion = emotion
             result.voice = voice_key
             result.speed = speed
-            
+
             # 3. 逐段生成音频
             for i, segment in enumerate(segments):
                 seg_result = SegmentTTSResult(segment=segment)
-                
+
                 try:
                     audio_path = await self.tts_processor.generate_audio(
                         segment.text,
                         voice_uri,
                         speed,
                         emotion=emotion,
+                        style_overrides=style_overrides,
                     )
-                    
+
                     if audio_path:
                         seg_result.audio_path = audio_path
                         seg_result.duration_seconds = await get_audio_duration(audio_path)
@@ -310,29 +330,29 @@ class SegmentedTTSProcessor:
                         logger.info(f"SegmentedTTS: segment {i+1}/{len(segments)} generated")
                     else:
                         seg_result.error = "audio generation failed"
-                        
+
                 except Exception as e:
                     seg_result.error = str(e)
                     logger.error(f"SegmentedTTS: segment {i+1} generation error: {e}")
-                
+
                 result.segments.append(seg_result)
-            
+
             if result.successful_segments:
                 result.success = True
-            
+
         except Exception as e:
             result.error = str(e)
             logger.error(f"SegmentedTTS: process_only failed: {e}", exc_info=True)
-        
+
         return result
-    
+
     def _calculate_interval(self, seg_result: SegmentTTSResult) -> float:
         """
         计算到下一段的等待时间。
-        
+
         Args:
             seg_result: 当前段的结果
-            
+
         Returns:
             等待时间（秒）
         """
@@ -345,21 +365,21 @@ class SegmentedTTSProcessor:
         else:
             # 固定间隔模式
             return self.fixed_interval
-    
+
     def should_use_segmented(self, text: str, min_chars: int = 50) -> bool:
         """
         判断是否应该使用分段模式。
-        
+
         Args:
             text: 待处理文本
             min_chars: 最小字符数阈值
-            
+
         Returns:
             是否应该使用分段模式
         """
         if not text or len(text) < min_chars:
             return False
-        
+
         # 估算分段数量
         estimated = self.splitter.estimate_segment_count(text)
         return estimated >= 2

--- a/core/session.py
+++ b/core/session.py
@@ -8,7 +8,7 @@ TTS Emotion Router - Session State
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Dict
+from typing import Optional, Dict, Any
 import time
 
 
@@ -16,9 +16,9 @@ import time
 class SessionState:
     """
     会话状态数据类。
-    
+
     用于跟踪每个会话（群组/用户）的 TTS 相关状态。
-    
+
     Attributes:
         last_ts: 最后一次 TTS 生成的时间戳（用于冷却计算）
         pending_emotion: 基于隐藏标记的待用情绪
@@ -38,6 +38,8 @@ class SessionState:
     """
     last_ts: float = 0.0
     pending_emotion: Optional[str] = None
+    pending_style_overrides: Optional[Dict[str, str]] = None
+    pending_voice: Optional[str] = None
     last_emotion: Optional[str] = None
     last_voice: Optional[str] = None
     last_tts_content: Optional[str] = None
@@ -54,18 +56,18 @@ class SessionState:
     text_voice_enabled: Optional[bool] = None
     suppress_next_llm_plain_text: bool = False
     suppress_next_llm_plain_text_until: float = 0.0
-    
+
     def update_tts_time(self) -> None:
         """更新最后 TTS 生成时间戳。"""
         now = time.time()
         self.last_ts = now
         self.last_tts_time = now
-    
+
     def set_tts_content(self, content: str) -> None:
         """设置最后的 TTS 内容。"""
         self.last_tts_content = content
         self.update_tts_time()
-    
+
     def set_assistant_text(self, text: str) -> None:
         """设置最近的助手文本。"""
         self.last_assistant_text = text.strip() if text else None
@@ -195,39 +197,52 @@ class SessionState:
             return False
         self.clear_next_llm_plain_text_suppression()
         return True
-    
+
     def consume_pending_emotion(self) -> Optional[str]:
-        """
-        消费并返回待用情绪。
-        
-        Returns:
-            待用情绪字符串，如果没有则返回 None
-        """
+        """消费并返回待用情绪。"""
         emotion = self.pending_emotion
         self.pending_emotion = None
         return emotion
-    
+
+    def set_pending_style_overrides(self, overrides: Dict[str, str]) -> None:
+        cleaned = {str(k): str(v).strip() for k, v in (overrides or {}).items() if str(v).strip()}
+        self.pending_style_overrides = cleaned or None
+
+    def consume_pending_style_overrides(self) -> Optional[Dict[str, str]]:
+        overrides = self.pending_style_overrides
+        self.pending_style_overrides = None
+        return overrides
+
+    def set_pending_voice(self, voice: str) -> None:
+        cleaned = str(voice or "").strip()
+        self.pending_voice = cleaned or None
+
+    def consume_pending_voice(self) -> Optional[str]:
+        voice = self.pending_voice
+        self.pending_voice = None
+        return voice
+
     def is_cooldown_expired(self, cooldown: int) -> bool:
         """
         检查冷却时间是否已过。
-        
+
         Args:
             cooldown: 冷却时间（秒）
-            
+
         Returns:
             如果冷却时间已过返回 True
         """
         if cooldown <= 0:
             return True
         return (time.time() - self.last_ts) >= cooldown
-    
+
     def get_remaining_cooldown(self, cooldown: int) -> float:
         """
         获取剩余冷却时间。
-        
+
         Args:
             cooldown: 冷却时间设置（秒）
-            
+
         Returns:
             剩余冷却时间（秒），如果已过冷却期返回 0
         """
@@ -241,47 +256,47 @@ class SessionState:
 class SessionManager:
     """
     会话状态管理器。
-    
+
     管理所有会话的状态，提供线程安全的访问接口。
     """
-    
+
     def __init__(self):
         """初始化会话管理器。"""
         self._sessions: Dict[str, SessionState] = {}
-    
+
     def get(self, session_id: str) -> SessionState:
         """
         获取或创建会话状态。
-        
+
         Args:
             session_id: 会话 ID
-            
+
         Returns:
             对应的会话状态对象
         """
         if session_id not in self._sessions:
             self._sessions[session_id] = SessionState()
         return self._sessions[session_id]
-    
+
     def get_or_none(self, session_id: str) -> Optional[SessionState]:
         """
         获取会话状态（不创建）。
-        
+
         Args:
             session_id: 会话 ID
-            
+
         Returns:
             会话状态对象，如果不存在返回 None
         """
         return self._sessions.get(session_id)
-    
+
     def remove(self, session_id: str) -> bool:
         """
         移除会话状态。
-        
+
         Args:
             session_id: 会话 ID
-            
+
         Returns:
             如果会话存在并被移除返回 True
         """
@@ -289,16 +304,16 @@ class SessionManager:
             del self._sessions[session_id]
             return True
         return False
-    
+
     def clear(self) -> None:
         """清空所有会话状态。"""
         self._sessions.clear()
-    
+
     @property
     def count(self) -> int:
         """获取当前会话数量。"""
         return len(self._sessions)
-    
+
     def __contains__(self, session_id: str) -> bool:
         """检查会话是否存在。"""
         return session_id in self._sessions

--- a/core/tts_processor.py
+++ b/core/tts_processor.py
@@ -45,6 +45,7 @@ class TTSProcessingResult:
     emotion: str = "neutral"
     voice: Optional[str] = None
     speed: float = 1.0
+    style_overrides: Optional[Dict[str, str]] = None
     text: str = ""
     success: bool = False
     error: str = ""
@@ -53,10 +54,10 @@ class TTSProcessingResult:
 class TTSConditionChecker:
     """
     TTS 条件检查器。
-    
+
     检查是否满足 TTS 生成的各种条件。
     """
-    
+
     def __init__(
         self,
         prob: float = 1.0,
@@ -67,7 +68,7 @@ class TTSConditionChecker:
     ):
         """
         初始化条件检查器。
-        
+
         Args:
             prob: TTS 触发概率
             text_limit: 文本长度上限
@@ -80,7 +81,7 @@ class TTSConditionChecker:
         self.text_min_limit = text_min_limit
         self.cooldown = cooldown
         self.allow_mixed = allow_mixed
-    
+
     def check_all(
         self,
         text: str,
@@ -91,12 +92,12 @@ class TTSConditionChecker:
     ) -> TTSCheckResult:
         """
         执行所有检查。
-        
+
         Args:
             text: 待合成文本
             session_state: 会话状态
             has_non_plain_elements: 消息链中是否包含非纯文本元素
-            
+
         Returns:
             检查结果
         """
@@ -105,59 +106,59 @@ class TTSConditionChecker:
             # 优先使用会话级设置，如果未设置则使用全局设置
             session_mixed = session_state.text_voice_enabled
             effective_mixed = session_mixed if session_mixed is not None else self.allow_mixed
-            
+
             if not effective_mixed:
                 return TTSCheckResult(False, "mixed content not allowed")
-        
+
         # 2. 文本长度下限检查
         if self.text_min_limit > 0 and len(text) < self.text_min_limit:
             return TTSCheckResult(False, f"text too short ({len(text)} < {self.text_min_limit})")
-        
+
         # 3. 文本长度上限检查
         if self.text_limit > 0 and len(text) > self.text_limit:
             return TTSCheckResult(False, f"text too long ({len(text)} > {self.text_limit})")
-        
+
         # 4. 冷却时间检查
         is_cd_ok, remaining = self.check_cooldown(session_state.last_ts)
         if not is_cd_ok:
             return TTSCheckResult(False, f"cooldown ({remaining:.1f}s)", remaining)
-            
+
         # 5. 概率检查
         if enable_probability:
             is_prob_ok, roll = self.check_probability()
             if not is_prob_ok:
                 return TTSCheckResult(False, f"probability check failed ({roll:.2f} > {self.prob})")
-            
+
         return TTSCheckResult(True)
-    
+
     def check_probability(self) -> Tuple[bool, float]:
         """检查概率条件。"""
         roll = random.random()
         return roll <= self.prob, roll
-    
+
     def check_cooldown(self, last_ts: float) -> Tuple[bool, float]:
         """检查冷却时间。"""
         if self.cooldown <= 0:
             return True, 0.0
-        
+
         now = time.time()
         elapsed = now - last_ts
         if elapsed >= self.cooldown:
             return True, 0.0
-        
+
         return False, self.cooldown - elapsed
 
 
 class TTSProcessor:
     """
     TTS 处理器类。
-    
+
     封装核心的 TTS 生成逻辑，包括：
     - 音色选择
     - 音频验证
     - TTS 生成调用
     """
-    
+
     def __init__(
         self,
         tts_client: Any,
@@ -167,7 +168,7 @@ class TTSProcessor:
     ):
         """
         初始化 TTS 处理器。
-        
+
         Args:
             tts_client: TTS 客户端实例
             voice_map: 情绪-音色映射
@@ -178,7 +179,7 @@ class TTSProcessor:
         self.voice_map = voice_map
         self.speed_map = speed_map
         self.heuristic_cls = heuristic_classifier
-    
+
     async def process(
         self,
         text: str,
@@ -186,45 +187,56 @@ class TTSProcessor:
     ) -> TTSProcessingResult:
         """
         处理 TTS 请求的主入口。
-        
+
         Args:
             text: 待合成文本
             session_state: 会话状态
-            
+
         Returns:
             处理结果
         """
         result = TTSProcessingResult(text=text)
-        
+
         try:
             # 1. 确定情绪
             emotion = self.determine_emotion(session_state, text)
             result.emotion = emotion
-            
+            style_overrides = session_state.consume_pending_style_overrides()
+            result.style_overrides = style_overrides
+            pending_voice = session_state.consume_pending_voice()
+
             # 2. 选择音色
-            voice_key, voice_uri = self.pick_voice_for_emotion(emotion)
+            if pending_voice:
+                voice_key, voice_uri = pending_voice, pending_voice
+            else:
+                voice_key, voice_uri = self.pick_voice_for_emotion(emotion)
             if not voice_uri:
-                result.success = False
-                result.error = f"no voice available for emotion: {emotion}"
-                logger.warning(f"TTS skip: {result.error}")
-                return result
-            
+                default_voice = str(getattr(self.tts, "voice", "") or getattr(self.tts, "voice_id", "") or "").strip()
+                if default_voice:
+                    voice_key, voice_uri = "default", default_voice
+                else:
+                    result.success = False
+                    result.error = f"no voice available for emotion: {emotion}"
+                    logger.warning(f"TTS skip: {result.error}")
+                    return result
+
             result.voice = voice_key
-            
+
             # 3. 确定语速
             speed = self.get_speed_for_emotion(emotion)
             result.speed = speed
-            
-            logger.info(f"TTS: emotion={emotion}, voice={voice_key}, speed={speed}")
-            
+
+            logger.info(f"TTS: emotion={emotion}, voice={voice_key}, speed={speed}, styles={style_overrides}")
+
             # 4. 生成音频
             audio_path = await self.generate_audio(
                 text,
                 voice_uri,
                 speed,
                 emotion=emotion,
+                style_overrides=style_overrides,
             )
-            
+
             if audio_path:
                 result.success = True
                 result.audio_path = audio_path
@@ -233,14 +245,14 @@ class TTSProcessor:
             else:
                 result.success = False
                 result.error = "audio generation failed"
-                
+
         except Exception as e:
             result.success = False
             result.error = str(e)
             logger.error(f"TTS process failed: {e}", exc_info=True)
-            
+
         return result
-    
+
     def _update_session_state(self, st: SessionState, result: TTSProcessingResult) -> None:
         """更新会话状态"""
         now = time.time()
@@ -248,55 +260,62 @@ class TTSProcessor:
         st.last_emotion = result.emotion
         st.last_voice = result.voice
         # 注意：不在这里设置 assistant_text，因为那属于发送逻辑
-    
+
     def pick_voice_for_emotion(self, emotion: str) -> Tuple[Optional[str], Optional[str]]:
         """根据情绪选择音色。"""
         vm = self.voice_map or {}
-        
+
         # exact match
         v = vm.get(emotion)
         if v:
             return emotion, v
-        
+
         # neutral fallback
         v = vm.get("neutral")
         if v:
             return "neutral", v
-        
+
         # preference mapping
         for key in [EMOTION_PREFERENCE_MAP.get(emotion), "happy", "angry"]:
             if key and vm.get(key):
                 return key, vm[key]
-        
+
         # any available
         for k, v in vm.items():
             if v:
                 return k, v
-        
+
         return None, None
-    
+
     def determine_emotion(
         self,
         session_state: SessionState,
         text: str
     ) -> str:
         """确定要使用的情绪。"""
+        # 唱歌是明确功能意图，应优先于上一轮残留的 pending emotion。
+        direct_emotion = self.heuristic_cls.classify(text)
+        if direct_emotion == "sing":
+            session_state.pending_emotion = None
+            logger.info("Direct singing intent detected")
+            return "sing"
+
         # 优先使用 pending emotion
         if session_state.pending_emotion and session_state.pending_emotion in EMOTIONS:
             emotion = session_state.pending_emotion
             session_state.pending_emotion = None
             logger.info("Using pending emotion: %s", emotion)
             return emotion
-        
+
         # 启发式分类
-        emotion = self.heuristic_cls.classify(text)
+        emotion = direct_emotion
         logger.info("Heuristic classified emotion: %s", emotion)
         return emotion
-    
+
     def get_speed_for_emotion(self, emotion: str) -> float:
         """获取情绪对应的语速。"""
         return self.speed_map.get(emotion, self.speed_map.get("neutral", 1.0))
-    
+
     async def generate_audio(
         self,
         text: str,
@@ -304,28 +323,39 @@ class TTSProcessor:
         speed: float,
         *,
         emotion: Optional[str] = None,
+        style_overrides: Optional[Dict[str, str]] = None,
     ) -> Optional[Path]:
         """生成 TTS 音频。"""
         try:
-            audio_path = await self.tts.synth(
-                text,
-                voice_uri,
-                TEMP_DIR,
-                speed=speed,
-                emotion=emotion,
-            )
-            
+            if type(self.tts).__name__ == "MiMoTTS":
+                audio_path = await self.tts.synth(
+                    text,
+                    voice_uri,
+                    TEMP_DIR,
+                    speed=speed,
+                    emotion=emotion,
+                    style_overrides=style_overrides,
+                )
+            else:
+                audio_path = await self.tts.synth(
+                    text,
+                    voice_uri,
+                    TEMP_DIR,
+                    speed=speed,
+                    emotion=emotion,
+                )
+
             if not audio_path:
                 logger.error("TTS returned empty path")
                 return None
-            
+
             audio_path = Path(audio_path)
             if not await self.validate_audio_file(audio_path):
                 logger.error("Audio file validation failed")
                 return None
-            
+
             return audio_path
-            
+
         except Exception as e:
             logger.error("TTS generation failed", exc_info=True)
             return None
@@ -333,7 +363,7 @@ class TTSProcessor:
     async def validate_audio_file(self, audio_path: Path) -> bool:
         """验证音频文件是否有效（异步）。"""
         return await validate_audio_file(audio_path)
-            
+
     def normalize_audio_path(self, audio_path: Path) -> str:
         """规范化音频文件路径。"""
         try:
@@ -352,21 +382,21 @@ class TTSProcessor:
 class TTSResultBuilder:
     """
     TTS 结果构建器。
-    
+
     负责构建最终的消息结果链。
     """
-    
+
     def __init__(self, plain_class: type, record_class: type):
         """
         初始化结果构建器。
-        
+
         Args:
             plain_class: Plain 消息组件类
             record_class: Record 消息组件类
         """
         self.Plain = plain_class
         self.Record = record_class
-    
+
     def build(
         self,
         original_chain: list,
@@ -376,25 +406,25 @@ class TTSResultBuilder:
     ) -> list:
         """
         构建包含音频的新消息链。
-        
+
         Args:
             original_chain: 原始消息链
             audio_path: 音频文件路径
             send_text: 要发送的文本内容
             text_voice_enabled: 是否同时发送文本
-            
+
         Returns:
             新的消息链
         """
         new_chain = []
-        
+
         # 1. 如果启用了文字+语音，先添加文字
         if text_voice_enabled and send_text.strip():
             new_chain.append(self.Plain(text=send_text))
-            
+
         # 2. 添加音频
         new_chain.append(self.Record(file=audio_path))
-        
+
         # 3. 保留非 Plain/Record 元素（如图片）
         # 这里的逻辑是：我们替换掉了原来的 Plain，增加了 Record，
         # 但如果是 Image 或其他组件，应该保留下来。
@@ -402,5 +432,5 @@ class TTSResultBuilder:
         for comp in original_chain:
             if not isinstance(comp, (self.Plain, self.Record)):
                 new_chain.append(comp)
-                
+
         return new_chain

--- a/emotion/infer.py
+++ b/emotion/infer.py
@@ -1,16 +1,23 @@
 from typing import List, Optional, Dict, Pattern, Set
 import re
 
-from ..core.constants import DEFAULT_EMOTION_KEYWORDS_LIST
-
-EMOTIONS: List[str] = ["neutral", "happy", "sad", "angry"]
+from ..core.constants import DEFAULT_EMOTION_KEYWORDS_LIST, EMOTION_KEYWORDS, EMOTIONS
 
 # 极简启发式情绪分类器，避免引入大模型依赖；后续可替换为 onnx 推理
 DEFAULT_KEYWORDS: Dict[str, Set[str]] = {
     k: set(v) for k, v in DEFAULT_EMOTION_KEYWORDS_LIST.items()
 }
+# Do not try to derive keyword strings from regex.pattern: escaped Chinese
+# sequences such as "\u59d4\u5c48" would become literal backslash text.
+# The compiled EMOTION_KEYWORDS regexes below provide the full 18-emotion
+# coverage; DEFAULT_KEYWORDS remains the user-editable simple keyword layer.
 
 URL_RE: Pattern = re.compile(r"https?://|www\.")
+SING_INTENT_RE: Pattern = re.compile(
+    r"(唱(?:首|一首|一句|歌)?|来(?:首|一首)|献唱|哼(?:首|一段)?|"
+    r"歌曲|歌词|开嗓|清唱|唱给|大海啊大海)",
+    re.I,
+)
 # 代码块检测
 CODE_BLOCK_RE: Pattern = re.compile(r'```[a-zA-Z0-9_+-]*\n.*?\n```', re.DOTALL)
 INLINE_CODE_RE: Pattern = re.compile(r'`([^`\n]+)`')
@@ -32,7 +39,7 @@ def is_informational(text: str) -> bool:
             len(code_content) > 20):
             has_inline_code = True
             break
-    
+
     return has_url or has_code_block or has_inline_code
 
 
@@ -42,17 +49,39 @@ def classify(text: str, context: Optional[List[str]] = None, keywords: Optional[
         return "neutral"
 
     t = (text or "").lower()
-    score: Dict[str, float] = {"happy": 0.0, "sad": 0.0, "angry": 0.0}
-    
-    # 使用传入的关键词或默认关键词
+
+    # 唱歌是用户的明确功能意图，必须高于普通情绪识别。
+    if SING_INTENT_RE.search(text or ""):
+        return "sing"
+
+    # 使用传入的关键词或默认关键词。支持配置里的扩展情绪（尤其 sing）。
     kw_map = keywords if keywords else DEFAULT_KEYWORDS
+
+    # 唱歌是明确意图，不应该被感叹号或其他情绪抢走。
+    for w in kw_map.get("sing", set()):
+        if w and w.lower() in t:
+            return "sing"
+
+    score: Dict[str, float] = {emo: 0.0 for emo in EMOTIONS if emo not in ("neutral", "sing")}
+    for emo in kw_map.keys():
+        if emo not in ("neutral", "sing"):
+            score.setdefault(emo, 0.0)
 
     # 简单计数词典命中
     for emo, words in kw_map.items():
+        if emo == "sing":
+            continue
         if emo in score:
             for w in words:
-                if w.lower() in t:
+                if w and w.lower() in t:
                     score[emo] += 1.0
+
+    # 内置正则覆盖 18 种情绪。
+    for emo, pattern in EMOTION_KEYWORDS.items():
+        if emo in ("sing", "neutral"):
+            continue
+        if emo in score and pattern.search(text or ""):
+            score[emo] += 1.0
 
     # 感叹号、全大写等作为情绪增强
     if text and "!" in text:
@@ -61,7 +90,7 @@ def classify(text: str, context: Optional[List[str]] = None, keywords: Optional[
         text
         and text.strip()
         and text == text.upper()
-        and any(c.isalpha() for c in text)
+        and any(("a" <= c.lower() <= "z") for c in text)
     ):
         score["angry"] += 1.0
 
@@ -73,9 +102,11 @@ def classify(text: str, context: Optional[List[str]] = None, keywords: Optional[
             ctx = "\n".join(valid_context[-3:]).lower()
             # 使用相同的关键词映射进行上下文加权
             for emo, words in kw_map.items():
+                if emo == "sing":
+                    continue
                 if emo in score:
                     for w in words:
-                        if w.lower() in ctx:
+                        if w and w.lower() in ctx:
                             score[emo] += 0.2
 
     # 选最大，否则中性

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import re
 import logging
 import time
 import heapq
@@ -40,6 +41,7 @@ from .core.constants import (
     PLUGIN_VERSION,
     TEMP_DIR,
     EMOTIONS,
+    MIMO_STYLE_LABEL_TO_CATEGORY,
     EMOTION_KEYWORDS,
     AUDIO_CLEANUP_TTL_SECONDS,
     SESSION_CLEANUP_INTERVAL_SECONDS,
@@ -60,6 +62,7 @@ from .core.text_splitter import TextSplitter
 from .emotion.classifier import HeuristicClassifier
 from .tts.provider_siliconflow import SiliconFlowTTS
 from .tts.provider_minimax import MiniMaxTTS
+from .tts.provider_mimo import MiMoTTS, MIMO_EMOTION_TAGS_REVERSE, MIMO_VOICES
 from .utils.audio import ensure_dir, cleanup_dir
 from .utils.extract import CodeAndLinkExtractor
 from .utils.text_sanitizer import PreparedSpeechText, SpeechTextSanitizer
@@ -171,6 +174,26 @@ class TTSEmotionRouter(Star):
                 timeout=api_cfg.get("timeout", 30),
             )
 
+        if provider == "mimo":
+            return MiMoTTS(
+                api_url=api_cfg["url"],
+                api_key=api_cfg["key"],
+                model=api_cfg["model"],
+                voice=api_cfg.get("voice", "mimo_default"),
+                fmt=api_cfg["format"],
+                speed=api_cfg["speed"],
+                max_retries=api_cfg.get("max_retries", 2),
+                timeout=api_cfg.get("timeout", 30),
+                style_prompt=api_cfg.get("style_prompt", ""),
+                overall_tone=api_cfg.get("overall_tone", ""),
+                timbre_positioning=api_cfg.get("timbre_positioning", ""),
+                persona_accent=api_cfg.get("persona_accent", ""),
+                dialect=api_cfg.get("dialect", ""),
+                role_play=api_cfg.get("role_play", ""),
+                seed_text=api_cfg.get("seed_text", ""),
+                sing_voice=api_cfg.get("sing_voice", ""),
+            )
+
         return SiliconFlowTTS(
             api_cfg["url"],
             api_cfg["key"],
@@ -187,7 +210,7 @@ class TTSEmotionRouter(Star):
         api_cfg = self.config.get_api_config()
         keys = (
             "provider", "url", "key", "model", "format", "speed", "gain", "sample_rate",
-            "voice_id", "vol", "pitch", "emotion", "bitrate", "channel", "subtitle_enable",
+            "voice_id", "voice", "sing_voice", "overall_tone", "timbre_positioning", "persona_accent", "dialect", "role_play", "vol", "pitch", "emotion", "bitrate", "channel", "subtitle_enable",
             "output_format", "language_boost", "proxy", "voice_modify", "timber_weights",
             "pronunciation_dict", "aigc_watermark", "max_retries", "timeout",
         )
@@ -712,6 +735,7 @@ class TTSEmotionRouter(Star):
             return False, [], "没有可用于语音合成的文本。"
 
         umo = self._get_umo(event)
+        self._publish_temporary_voice_directives(event, text)
         st = self._get_session_state(umo)
         proc_res = await self.tts_processor.process(tts_text, st)
         if not proc_res.success or not proc_res.audio_path:
@@ -749,11 +773,71 @@ class TTSEmotionRouter(Star):
             logging.error("manual tts send failed: %s", e)
             return f"发送失败：{e}"
 
+    def _extract_temporary_voice_directives(self, text: str) -> Tuple[Optional[str], Dict[str, str], Optional[str]]:
+        """Extract one-turn MiMo style/emotion/voice directives from user text.
+
+        Voice names are only accepted with an explicit speech context such as
+        “用冰糖的音色说” or “用 Mia 的声音说”, avoiding accidental triggers in
+        ordinary chat.
+        """
+        raw = str(text or "")
+        if not raw.strip():
+            return None, {}, None
+
+        pending_emotion: Optional[str] = None
+        for zh_label, emotion_key in MIMO_EMOTION_TAGS_REVERSE.items():
+            if emotion_key in EMOTIONS and zh_label in raw:
+                pending_emotion = emotion_key
+
+        style_overrides: Dict[str, str] = {}
+        for label, category in MIMO_STYLE_LABEL_TO_CATEGORY.items():
+            if label in raw:
+                style_overrides[category] = label
+
+        pending_voice: Optional[str] = None
+        for voice_name in sorted(MIMO_VOICES.keys(), key=len, reverse=True):
+            if voice_name == "mimo_default":
+                continue
+            # Strong context only: “用/换成/切到 + voice + 的? + 音色/声音/声线/嗓音”.
+            pattern = rf"(?:用|换成|切到|改成|使用|采用)\s*{re.escape(voice_name)}\s*(?:的)?\s*(?:音色|声音|声线|嗓音)"
+            if re.search(pattern, raw, re.I):
+                pending_voice = voice_name
+                break
+
+        return pending_emotion, style_overrides, pending_voice
+
+    def _publish_temporary_voice_directives(self, event: AstrMessageEvent, text: str) -> None:
+        # MiMo-only: these directives use MiMo preset voices and Chinese style tags.
+        # Do not leak them to MiniMax/SiliconFlow where they may be invalid voice ids.
+        if self.config.get_tts_provider() != "mimo":
+            return
+
+        emotion, style_overrides, pending_voice = self._extract_temporary_voice_directives(text)
+        if not emotion and not style_overrides and not pending_voice:
+            return
+        st = self._get_session_state(self._get_umo(event))
+        if emotion:
+            st.pending_emotion = emotion
+        if style_overrides:
+            st.set_pending_style_overrides(style_overrides)
+        if pending_voice:
+            st.set_pending_voice(pending_voice)
+        logger.info(
+            "temporary MiMo voice directives sid=%s emotion=%s styles=%s voice=%s",
+            self._get_umo(event),
+            emotion,
+            style_overrides,
+            pending_voice,
+        )
+
     # ---------------- llm hooks ----------------
 
     @filter.on_llm_request()
     async def on_llm_request(self, event: AstrMessageEvent, request):
         try:
+            user_prompt = str(getattr(request, "prompt", "") or "")
+            if user_prompt:
+                self._publish_temporary_voice_directives(event, user_prompt)
             await self._inject_recent_spoken_assistant_context(event, request)
             marker_mode = self.publish_output_marker_mode(event)
             if not self._should_inject_minimax_prompt(event):
@@ -840,7 +924,7 @@ class TTSEmotionRouter(Star):
         try:
             umo = self._get_umo(event)
             st = self._get_session_state(umo)
-            if label in EMOTIONS:
+            if label in EMOTIONS and not st.pending_emotion:
                 st.pending_emotion = label
             if visible_text:
                 st.set_assistant_text(visible_text)
@@ -1284,7 +1368,13 @@ class TTSEmotionRouter(Star):
 
             ok, chain, history_or_error = await self._build_manual_tts_chain(event, content)
             if not ok:
-                yield history_or_error
+                logging.warning("tts_speak synthesis failed: %s", history_or_error)
+                event.clear_result()
+                # Do not expose the low-level failure text to the LLM.  If the
+                # model sees "audio generation failed", it tends to roleplay a
+                # broken voice ("嗓子被封印") and sends confusing fallback text.
+                yield None
+                yield "语音请求已处理。"
                 return
 
             history_text = history_or_error.strip()

--- a/tts/provider_mimo.py
+++ b/tts/provider_mimo.py
@@ -1,0 +1,509 @@
+# -*- coding: utf-8 -*-
+"""MiMo TTS Provider - 适配小米 MiMo TTS API"""
+
+import base64
+import hashlib
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+import aiohttp
+import asyncio
+
+from ..utils.audio import validate_audio_file
+
+logger = logging.getLogger(__name__)
+
+# MiMo TTS 预置音色
+MIMO_VOICES = {
+    "mimo_default": "mimo_default",
+    "冰糖": "冰糖",
+    "茉莉": "茉莉",
+    "苏打": "苏打",
+    "白桦": "白桦",
+    "Mia": "Mia",
+    "Chloe": "Chloe",
+    "Milo": "Milo",
+    "Dean": "Dean",
+}
+
+# MiMo TTS 情绪标签（英文 key -> 中文标签）
+MIMO_EMOTION_TAGS = {
+    # 基础情绪
+    "neutral": "平静",
+    "happy": "开心",
+    "sad": "悲伤",
+    "angry": "愤怒",
+    "surprise": "惊讶",
+    "fear": "恐惧",
+    "excited": "兴奋",
+    "wronged": "委屈",
+    "cold": "冷漠",
+    # 复合情绪
+    "melancholy": "怅然",
+    "gratified": "欣慰",
+    "helpless": "无奈",
+    "guilty": "愧疚",
+    "relieved": "释然",
+    "jealous": "嫉妒",
+    "weary": "厌倦",
+    "anxious": "忐忑",
+    "affectionate": "动情",
+    # 整体语调
+    "gentle": "温柔",
+    "cool": "高冷",
+    "lively": "活泼",
+    "serious": "严肃",
+    "lazy": "慵懒",
+    "playful": "俏皮",
+    "deep": "深沉",
+    "capable": "干练",
+    "sharp": "凌厉",
+    # 音色定位
+    "magnetic": "磁性",
+    "mellow": "醇厚",
+    "clear": "清亮",
+    "ethereal": "空灵",
+    "young": "稚嫩",
+    "old": "苍老",
+    "sweet": "甜美",
+    "hoarse": "沙哑",
+    "elegant": "醇雅",
+    # 人设腔调
+    "jiazisheng": "夹子音",
+    "yujie": "御姐音",
+    "zhengtai": "正太音",
+    "dashu": "大叔音",
+    "taiwan": "台湾腔",
+    # 方言
+    "dongbei": "东北话",
+    "sichuan": "四川话",
+    "henan": "河南话",
+    "cantonese": "粤语",
+    # 角色扮演
+    "sunwukong": "孙悟空",
+    "lindaiyu": "林黛玉",
+    # 特殊标签
+    "sing": "唱歌",
+}
+
+# 反向映射（中文标签 -> 英文 key）
+MIMO_EMOTION_TAGS_REVERSE = {v: k for k, v in MIMO_EMOTION_TAGS.items()}
+
+MIMO_STYLE_FIELD_NAMES = (
+    "overall_tone",
+    "timbre_positioning",
+    "persona_accent",
+    "dialect",
+    "role_play",
+)
+
+
+STRICT_SING_CACHE_VERSION = "strict-sing-v2"
+
+
+SINGING_CHATTER_RE = re.compile(
+    r"(好嘞|好的|安排|来首|应景|献上|听好|听着|给你唱|我来唱|今天第几首|"
+    r"门票|结一下|小子|老铁|家人们|下面|接下来|一首|唱(?:首|一首|一句|歌)?)"
+)
+
+
+def _is_sing_tag(value: Optional[str]) -> bool:
+    return str(value or "").strip().lower() in {"sing", "singing", "唱歌"}
+
+
+class MiMoTTS:
+    """MiMo TTS Provider - 适配小米 MiMo TTS API
+
+    MiMo TTS 使用 /v1/chat/completions 端点，而不是 /audio/speech。
+    情绪和唱歌功能通过括号格式控制，如：(唱歌)文本、(开心)文本
+    """
+
+    def __init__(
+        self,
+        api_url: str,
+        api_key: str,
+        model: str = "mimo-v2.5-tts",
+        voice: str = "mimo_default",
+        fmt: str = "mp3",
+        speed: float = 1.0,
+        max_retries: int = 2,
+        timeout: int = 30,
+        *,
+        style_prompt: str = "",
+        dialect: str = "",
+        seed_text: str = "",
+        sing_voice: str = "",
+        overall_tone: str = "",
+        timbre_positioning: str = "",
+        persona_accent: str = "",
+        role_play: str = "",
+    ):
+        self.api_url = (api_url or "https://api.xiaomimimo.com/v1").rstrip("/")
+        self.api_key = api_key or ""
+        self.model = model
+        self.voice = voice
+        self.format = fmt
+        self.speed = speed
+        self.max_retries = max_retries
+        self.timeout = timeout
+        self.style_prompt = style_prompt
+        self.overall_tone = overall_tone
+        self.timbre_positioning = timbre_positioning
+        self.persona_accent = persona_accent
+        self.dialect = dialect
+        self.role_play = role_play
+        self.seed_text = seed_text
+        # Empty sing_voice means "follow the main/default voice".  Use a
+        # concrete main voice such as 冰糖/茉莉 if you need stable timbre; the
+        # MiMo backend alias "mimo_default" may vary by deployment cluster.
+        self.sing_voice = sing_voice or ""
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def close(self):
+        """关闭 HTTP 会话"""
+        if self._session:
+            await self._session.close()
+            self._session = None
+
+    def _build_style_prefix(self, emotion_tag: Optional[str] = None, style_overrides: Optional[Dict[str, str]] = None) -> str:
+        """构建情绪标签前缀
+
+        根据小米官方文档，情绪标签使用括号格式：
+        - (唱歌)文本
+        - (开心)文本
+        - （唱歌）文本（全角括号也可以）
+
+        Args:
+            emotion_tag: 情绪标签（如"唱歌"、"开心"等）
+
+        Returns:
+            括号格式的情绪标签字符串，如果没有情绪标签则返回空字符串
+        """
+        style_parts: list[str] = []
+
+        # 优先使用传入的情绪标签
+        if emotion_tag:
+            style_parts.append(emotion_tag)
+
+        overrides = style_overrides or {}
+
+        for field in MIMO_STYLE_FIELD_NAMES:
+            value = str(overrides.get(field) or getattr(self, field, "") or "").strip()
+            if value:
+                style_parts.append(value)
+
+        # 兼容旧配置：额外自由风格标签仍可叠加在最后。
+        if self.style_prompt.strip():
+            style_parts.append(self.style_prompt.strip())
+
+        style_content = "、".join(style_parts).strip()
+        if not style_content:
+            return ""
+
+        # 使用括号格式（小米官方文档推荐）
+        return f"（{style_content}）"
+
+    def _build_user_prompt(self) -> Optional[str]:
+        """构建 user prompt.
+
+        Per MiMo docs, user messages are optional natural-language style
+        instructions or conversation history and are not spoken.  Leave empty
+        by default; do not inject arbitrary seed text.
+        """
+        seed_text = self.seed_text.strip()
+        return seed_text if seed_text else None
+
+    def _prepare_strict_sing_text(self, text: str) -> str:
+        """把用户/LLM 的唱歌式回复压成更像歌词的文本。
+
+        MiMo 的“唱歌”标签更容易在歌词体上生效；如果把“好嘞、给你来首、
+        门票记得结一下”这类对白一起交给模型，它经常会按台词朗读。
+        这里不尝试创作新内容，只做轻量清洗和分行。
+        """
+        raw = (text or "").strip()
+        if not raw:
+            return "啦啦啦，啦啦啦\n唱一段小小的歌"
+
+        # 去掉常见引号/标签/前置说明。
+        cleaned = re.sub(r"^\s*[《「『“\"']|[》」』”\"']\s*$", "", raw)
+        cleaned = re.sub(r"^\s*(?:唱(?:首|一首|一句|歌)?[:：，,\s]*)+", "", cleaned)
+        cleaned = SINGING_CHATTER_RE.sub("", cleaned)
+
+        # 去掉明显的闲聊句，保留更像歌词的内容。
+        parts = re.split(r"([。！？!?；;，,\n])", cleaned)
+        merged: list[str] = []
+        for idx in range(0, len(parts), 2):
+            sent = (parts[idx] or "").strip()
+            punct = parts[idx + 1] if idx + 1 < len(parts) else ""
+            if not sent:
+                continue
+            if re.search(r"(哈哈|呵呵|记得|别忘|怎么样|可以吗|要不要|不是|就是|这个|那个)", sent):
+                continue
+            merged.append(sent + (punct if punct and punct != "," else ""))
+
+        lyric = "".join(merged).strip(" ，,。；;")
+        if not lyric:
+            lyric = raw.strip()
+
+        # 分行增强“歌词体”。太短时补一个哼唱尾句，减少纯朗读概率。
+        lyric = re.sub(r"[。！？!?；;]+", "\n", lyric)
+        lyric = re.sub(r"[，,、]+", "\n", lyric)
+        lines = []
+        for line in lyric.splitlines():
+            line = line.strip(" ，,。；;")
+            line = re.sub(r"^[的了啊呀呢嘛吧]+", "", line)
+            line = re.sub(r"[的了啊呀呢嘛吧]+$", "", line)
+            if line and line not in {"的", "了", "啊", "呀", "呢", "嘛", "吧"}:
+                lines.append(line)
+        if len("".join(lines)) < 14:
+            lines.append("啦啦啦，轻轻唱")
+        return "\n".join(lines[:8])
+
+    def _build_strict_sing_user_prompt(self) -> str:
+        return (
+            "请严格按“唱歌/旋律哼唱”的方式生成音频，不要朗读，不要说话，"
+            "不要播报说明。下一条 assistant 内容是歌词，请把每一行都唱出来。"
+        )
+
+    def _build_payload(
+        self,
+        text: str,
+        emotion_tag: Optional[str] = None,
+        actual_voice: Optional[str] = None,
+        *,
+        strict_sing: bool = False,
+        style_overrides: Optional[Dict[str, str]] = None,
+    ) -> dict:
+        """构建 MiMo TTS API 请求 payload
+
+        Args:
+            text: 要合成的文本
+            emotion_tag: 情绪标签（如"唱歌"、"开心"等）
+
+        Returns:
+            API 请求 payload
+        """
+        messages: list[dict[str, str]] = []
+
+        # 添加 user prompt（seed text）
+        user_prompt = self._build_strict_sing_user_prompt() if strict_sing else self._build_user_prompt()
+        if user_prompt:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": user_prompt,
+                }
+            )
+
+        # 构建 assistant content（带 style 标签）
+        synth_text = self._prepare_strict_sing_text(text) if strict_sing else text
+        style_prefix = self._build_style_prefix(emotion_tag, style_overrides=style_overrides)
+        assistant_content = f"{style_prefix}{synth_text}" if style_prefix else synth_text
+        if strict_sing:
+            logger.info("MiMoTTS: strict singing content=%r", assistant_content[:200])
+        messages.append(
+            {
+                "role": "assistant",
+                "content": assistant_content,
+            }
+        )
+
+        # 构建 audio 参数
+        audio_params: dict = {"format": self.format}
+        # voicedesign 模型不支持 audio.voice 参数；voiceclone 使用 audio.voice
+        # 传入 data:{MIME_TYPE};base64,... 音频样本。
+        if "voicedesign" not in self.model:
+            audio_params["voice"] = actual_voice or self.voice
+
+        return {
+            "model": self.model,
+            "messages": messages,
+            "audio": audio_params,
+        }
+
+    async def synth(
+        self,
+        text: str,
+        voice: str,
+        out_dir: Path,
+        speed: Optional[float] = None,
+        *,
+        emotion: Optional[str] = None,
+        style_overrides: Optional[Dict[str, str]] = None,
+    ) -> Optional[Path]:
+        """合成语音
+
+        Args:
+            text: 要合成的文本
+            voice: 音色或情绪标签
+            out_dir: 输出目录
+            speed: 语速（MiMo TTS 暂不支持）
+            emotion: 情绪标签
+
+        Returns:
+            生成的音频文件路径，失败返回 None
+        """
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        # 解析 voice/emotion 参数：
+        # - emotion 是插件识别出的情绪 key（如 sing/happy），必须优先用于 MiMo 风格标签
+        # - voice 可能是实际音色，也可能是 voice_map 里的中文标签（如 唱歌/开心）
+        emotion_tag = None
+        actual_voice = self.voice
+
+        if emotion in MIMO_EMOTION_TAGS:
+            emotion_tag = MIMO_EMOTION_TAGS[emotion]
+        elif emotion in MIMO_EMOTION_TAGS_REVERSE:
+            emotion_tag = emotion
+        elif emotion and emotion not in ("neutral", "mimo_default"):
+            emotion_tag = emotion
+
+        if voice in MIMO_VOICES:
+            actual_voice = MIMO_VOICES[voice]
+        elif voice in MIMO_EMOTION_TAGS and not emotion_tag:
+            # 是英文情绪标签
+            emotion_tag = MIMO_EMOTION_TAGS[voice]
+        elif voice in MIMO_EMOTION_TAGS_REVERSE and not emotion_tag:
+            # 是中文情绪标签（如"唱歌"、"开心"）
+            emotion_tag = voice
+        elif voice and voice not in ("mimo_default",) and not emotion_tag:
+            # 尝试作为情绪标签处理
+            emotion_tag = voice
+
+        supports_singing = self.model == "mimo-v2.5-tts"
+        strict_sing = supports_singing and (
+            _is_sing_tag(emotion) or _is_sing_tag(voice) or _is_sing_tag(emotion_tag)
+        )
+        if not supports_singing and (_is_sing_tag(emotion) or _is_sing_tag(voice) or _is_sing_tag(emotion_tag)):
+            logger.warning("MiMoTTS: model %s does not support singing; ignoring sing tag", self.model)
+            emotion_tag = None
+        if strict_sing:
+            emotion_tag = "唱歌"
+            if self.sing_voice:
+                if self.sing_voice in MIMO_VOICES:
+                    actual_voice = MIMO_VOICES[self.sing_voice]
+                else:
+                    actual_voice = self.sing_voice
+
+        # 缓存 key
+        key = hashlib.sha256(
+            json.dumps(
+                {
+                    "t": text,
+                    "v": actual_voice,
+                    "m": self.model,
+                    "e": emotion_tag,
+                    "f": self.format,
+                    "strict_sing": STRICT_SING_CACHE_VERSION if strict_sing else "",
+                    "style_overrides": style_overrides or {},
+                },
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()[:16]
+        out_path = out_dir / f"{key}.{self.format}"
+        if out_path.exists() and out_path.stat().st_size > 0:
+            return out_path
+
+        if not self.api_url or not self.api_key:
+            logger.error("MiMoTTS: 缺少 api_url 或 api_key")
+            return None
+
+        # 构建请求
+        url = f"{self.api_url}/chat/completions"
+        headers = {
+            "api-key": self.api_key,
+            "Content-Type": "application/json",
+        }
+        payload = self._build_payload(
+            text,
+            emotion_tag,
+            actual_voice=actual_voice,
+            strict_sing=strict_sing,
+            style_overrides=style_overrides,
+        )
+        if strict_sing:
+            logger.info("MiMoTTS: strict singing mode enabled")
+
+        last_err = None
+        backoff = 1.0
+
+        # 懒加载 session
+        if self._session is None or self._session.closed:
+            client_timeout = aiohttp.ClientTimeout(total=self.timeout)
+            self._session = aiohttp.ClientSession(timeout=client_timeout)
+
+        for attempt in range(1, self.max_retries + 2):
+            try:
+                async with self._session.post(
+                    url, headers=headers, json=payload
+                ) as r:
+                    if 200 <= r.status < 300:
+                        # MiMo TTS 返回 JSON，音频在 message.audio.data 中
+                        data = await r.json()
+                        choices = data.get("choices") or []
+                        first_choice = choices[0] if choices else {}
+                        message = first_choice.get("message", {})
+                        audio_data = message.get("audio", {}).get("data")
+
+                        if not audio_data:
+                            logger.error(f"MiMoTTS: 返回无音频数据: {data}")
+                            last_err = {"error": "No audio data in response"}
+                            break
+
+                        # 解码 base64 音频并写入文件
+                        audio_bytes = base64.b64decode(audio_data)
+
+                        def _write_file():
+                            with open(out_path, "wb") as f:
+                                f.write(audio_bytes)
+                        await asyncio.to_thread(_write_file)
+
+                        # 验证生成的文件
+                        if not await validate_audio_file(out_path, expected_format=self.format):
+                            logger.error(f"MiMoTTS: 生成的文件验证失败: {out_path}")
+                            last_err = {"error": "Generated audio file validation failed"}
+                            break
+
+                        logger.info(f"MiMoTTS: 成功生成音频文件: {out_path} ({out_path.stat().st_size}字节)")
+                        return out_path
+
+                    # 非 2xx
+                    err_detail = None
+                    try:
+                        err_detail = await r.json()
+                    except Exception:
+                        text_content = await r.text()
+                        err_detail = {"error": text_content[:200]}
+
+                    logger.warning(
+                        f"MiMoTTS: 请求失败({r.status}) attempt={attempt}, detail={err_detail}"
+                    )
+                    last_err = err_detail
+                    if r.status in (429,) or 500 <= r.status < 600:
+                        if attempt <= self.max_retries:
+                            await asyncio.sleep(backoff)
+                            backoff = min(backoff * 2, 8)
+                            continue
+                    break
+            except Exception as e:
+                logger.warning(f"MiMoTTS: 网络异常 attempt={attempt}, err={e}")
+                last_err = str(e)
+                if attempt <= self.max_retries:
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, 8)
+                    continue
+                break
+
+        # 失败清理
+        try:
+            def _cleanup():
+                if out_path.exists() and out_path.stat().st_size == 0:
+                    out_path.unlink()
+            await asyncio.to_thread(_cleanup)
+        except Exception:
+            pass
+        logger.error(f"MiMoTTS: 合成失败，已放弃。last_error={last_err}")
+        return None


### PR DESCRIPTION
## 摘要

本 PR 增加小米 MiMo TTS 服务商支持，并扩展中文语境下的情绪路由能力：

- 新增 `mimo` TTS provider，支持 MiMo Chat Completions 风格 TTS 接口
- 将情绪路由从基础四类扩展为 18 种中文语境情绪
- 为 MiMo 增加情绪标签、唱歌、整体语调、音色定位、人设腔调、方言、角色扮演等风格控制
- 支持用户在对话中一次性临时指定 MiMo 风格或预置音色
- 保持 `voice_map` provider-neutral，避免 MiMo 中文标签影响 MiniMax/SiliconFlow

## 主要改动

### MiMo TTS provider

新增 `tts/provider_mimo.py`：

- 支持 `mimo-v2.5-tts` / `mimo-v2.5-tts-voicedesign` / `mimo-v2.5-tts-voiceclone`
- 支持预置音色：`冰糖`、`茉莉`、`苏打`、`白桦`、`Mia`、`Chloe`、`Milo`、`Dean`
- 使用 MiMo 支持的中文括号风格标签，例如：`（开心）文本`、`（委屈、东北话）文本`
- 对 `sing` 做专门处理，尽量将文本整理成歌词形式，提升唱歌标签的生效概率

### 18 种情绪路由

新增/扩展情绪：

- 基础情绪：开心、悲伤、愤怒、恐惧、惊讶、兴奋、委屈、平静、冷漠
- 复合情绪：怅然、欣慰、无奈、愧疚、释然、嫉妒、厌倦、忐忑、动情

这些情绪 key 是通用情绪路由能力，其他供应商也可以手动映射到自己的 voice id。

### MiMo 专属风格配置

在 MiMo 配置中新增 5 个独立配置项：

- 整体语调：温柔/高冷/活泼/严肃/慵懒/俏皮/深沉/干练/凌厉
- 音色定位：磁性/醇厚/清亮/空灵/稚嫩/苍老/甜美/沙哑/醇雅
- 人设腔调：夹子音/御姐音/正太音/大叔音/台湾腔
- 方言：东北话/四川话/河南话/粤语
- 角色扮演：孙悟空/林黛玉

### 对话临时指定

当 provider 为 `mimo` 时，支持用户在对话中一次性指定风格或音色，例如：

- `用东北话说一下……`
- `用夹子音说……`
- `用孙悟空的感觉说……`
- `用冰糖的音色说……`
- `换成 Mia 的声音说……`

其中临时音色采用较强语境匹配，必须出现“音色/声音/声线/嗓音”等词，避免普通聊天误触发。

### 兼容性处理

- `voice_map` 默认保持 provider-neutral，不向全局默认写入 MiMo 中文标签
- MiMo 在 `voice_map` 留空时，会根据 emotion 自动添加对应中文风格标签
- MiniMax/SiliconFlow 不会收到 MiMo 专属风格参数
- 如果 `voice_map` 未配置，TTS 会回退到当前服务商默认音色

## 测试

已执行：

```bash
python -m py_compile main.py core/constants.py core/config.py core/session.py core/marker.py core/tts_processor.py core/segmented_tts.py emotion/infer.py tts/provider_mimo.py tts/provider_minimax.py tts/provider_siliconflow.py

git diff --check
```

并本地验证：

- MiMo provider 可生成带情绪/风格前缀的 payload
- `voice_map` 留空时 MiMo 仍能按 emotion 自动添加中文标签
- 对话临时指定风格/音色只在 `provider=mimo` 时生效
- 切换到其他 provider 时，不会将 MiMo 中文标签作为默认 voice id 传入
